### PR TITLE
Remove superfluous console logging

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -163,7 +163,6 @@
      */
     API.autoTableEndPosY = function () {
         if (typeof cursor === 'undefined' || typeof cursor.y === 'undefined') {
-            console.error("autoTableEndPosY() called without autoTable() being called first");
             return 0;
         }
         return cursor.y;


### PR DESCRIPTION
Calling autoTableEndPosY() without an existing table fails gracefully (it returns 0). The console error message is misleading (it's not really an error) and unnecessary.