### PR TITLE
Gather header elements using getElementsByTagName to circumvent IE issues

### DIFF
--- a/dist/jspdf.plugin.autotable.src.js
+++ b/dist/jspdf.plugin.autotable.src.js
@@ -182,7 +182,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
     API.autoTableHtmlToJson = function (tableElem, includeHiddenRows) {
         includeHiddenRows = includeHiddenRows || false;
 
-        var header = tableElem.rows[0];
+        var header = tableElem.getElementsByTagName('tr')[0];
         var result = { columns: [], rows: [] };
 
         for (var k = 0; k < header.cells.length; k++) {


### PR DESCRIPTION
With some complex tables, the ```tableElem.rows``` property would return an empty ```<HtmlCollection>``` in Internet Explorer. Gathering the first ```<tr>``` skirts the issue. No issues in Chrome, FF, IE.