### PR TITLE
Header Style by cell

### DIFF
--- a/src/creator.ts
+++ b/src/creator.ts
@@ -96,7 +96,8 @@ export function createModels(inputHeaders, inputData) {
         table.columns.push(col);
 
         let cell = new Cell(rawColumn);
-        cell.styles = Config.styles([theme.table, theme.header, table.styles.styles, table.styles.headerStyles]);
+        let headerStyles = table.styles.headerStyles[dataKey] || {};
+        cell.styles = Config.styles([theme.table, theme.header, table.styles.styles, table.styles.headerStyles,headerStyles]);
 
         if (cell.raw instanceof HTMLElement) {
             cell.text = (cell.raw.innerText || '').trim();


### PR DESCRIPTION
Add capability to create custom style for each header, I added variable headerStyles to get the stile on the same way it gets the stiles for the body cells and let us create custom style for each header like on the body I added this variable on the array next to table.styles.headerStyles to be able to get the style when we define the same stile for all the header cells. This is the way I found to make it work since I need to create different halign for each header. 
Please let me know your thoughts,