### PR TITLE
Fix #334 in v3 to calculate linebreaks for other units.

### DIFF
--- a/src/widthCalculator.ts
+++ b/src/widthCalculator.ts
@@ -121,7 +121,7 @@ function fitContent(table) {
             if (cell.styles.overflow === 'linebreak') {
                 cell.text = Array.isArray(cell.text) ? cell.text.join(' ') : cell.text;
                 // Add one pt to textSpace to fix rounding error
-                cell.text = state().doc.splitTextToSize(cell.text, textSpace + 1, {fontSize: cell.styles.fontSize});
+                cell.text = state().doc.splitTextToSize(cell.text, textSpace + 1 / (state().scaleFactor() || 1), {fontSize: cell.styles.fontSize});
             } else if (cell.styles.overflow === 'ellipsize') {
                 cell.text = ellipsize(cell.text, textSpace, cell.styles);
             } else if (cell.styles.overflow === 'hidden') {


### PR DESCRIPTION
Fixes #334 Overflow 'linebreak' should use scaleFactor() when adding on pt for rounding error for v3 branch. Contributes towards support for other units (such as inches).