### PR TITLE
Feature row break never

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -48,7 +48,7 @@ export function getDefaults() {
         // Properties
         startY: false, // false indicates the margin top value
         margin: 40 / scaleFactor,
-        pageBreak: 'auto', // 'auto', 'avoid', 'always'
+        pageBreak: 'auto', // 'auto', 'avoid', 'always', 'never'
         tableWidth: 'auto', // 'auto'|'wrap'|number (takes precedence over columnWidth style if conflict)
         showHeader: 'everyPage', // 'everyPage', 'firstPage', 'never',
         tableLineWidth: 0,

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,7 +48,8 @@ export function getDefaults() {
         // Properties
         startY: false, // false indicates the margin top value
         margin: 40 / scaleFactor,
-        pageBreak: 'auto', // 'auto', 'avoid', 'always', 'never'
+        pageBreak: 'auto', // 'auto', 'avoid', 'always'
+        rowBreak: 'auto', // 'auto', 'never'
         tableWidth: 'auto', // 'auto'|'wrap'|number (takes precedence over columnWidth style if conflict)
         showHeader: 'everyPage', // 'everyPage', 'firstPage', 'never',
         tableLineWidth: 0,

--- a/src/painter.ts
+++ b/src/painter.ts
@@ -8,7 +8,7 @@ export function printFullRow(row, drawRowHooks, drawCellHooks) {
     let table = Config.tableInstance();
 
     if (!canFitOnPage(row.height)) {
-        if (row.maxLineCount <= 1 || table.settings.pageBreak === 'never') {
+        if (row.maxLineCount <= 1 || table.settings.rowBreak === 'never') {
             addPage();
         } else {
             // Modify the row to fit the current page and calculate text and height of partial row

--- a/src/painter.ts
+++ b/src/painter.ts
@@ -8,7 +8,7 @@ export function printFullRow(row, drawRowHooks, drawCellHooks) {
     let table = Config.tableInstance();
 
     if (!canFitOnPage(row.height)) {
-        if (row.maxLineCount <= 1) {
+        if (row.maxLineCount <= 1 || table.settings.pageBreak === 'never') {
             addPage();
         } else {
             // Modify the row to fit the current page and calculate text and height of partial row


### PR DESCRIPTION
For some applications, people may not want large rows to break across pages at all, and instead go immediately to the next page instead. This adds an option for that.