### PR TITLE
Typing improvements

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -160,7 +160,9 @@ export interface BaseConfig {
 	headStyles?: Styles;
 	footStyles?: Styles;
 	alternateRowStyles?: Styles;
-	columnStyles?: Styles;
+	columnStyles?: {
+		[key: string]: Styles;
+	};
 	didParseCell?: (data: CellHookData) => void;
 	willDrawCell?: (data: CellHookData) => void;
 	didDrawCell?: (data: CellHookData) => void;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -108,7 +108,13 @@ declare class CellHookData extends HookData {
 	section: 'head' | 'body' | 'foot';
 	constructor(cell: Cell, row: Row, column: Column);
 }
-export declare type UserOptions = HTMLConfig | ContentConfig;
+export interface ColumnOption {
+	header?: string;
+	title?: string;
+	footer?: string;
+	dataKey?: string | number;
+}
+export declare type UserOptions = HTMLConfig | ContentConfig | ColumnDataConfig;
 export declare type Color = [number, number, number] | number | 'transparent' | false;
 export declare type MarginPadding = number | {
 	top?: number;
@@ -172,6 +178,10 @@ export interface ContentConfig extends BaseConfig {
 	head?: SingleRowType | MultipleRowType;
 	foot?: SingleRowType | MultipleRowType;
 	body: MultipleRowType;
+}
+export interface ColumnDataConfig extends BaseConfig {
+	columns?: ColumnOption[];
+	body: object[];
 }
 export interface HTMLConfig extends BaseConfig {
 	html: string | HTMLElement;

--- a/examples/typescript/index.ts
+++ b/examples/typescript/index.ts
@@ -6,7 +6,7 @@ import 'jspdf-autotable';
 // defined and the way jspdf is exported makes it hard to implement
 // https://stackoverflow.com/q/55328516/827047
 
-type AutoTable = import('jspdf-autotable').autoTable;
+import { autoTable as AutoTable } from 'jspdf-autotable';
 
 // stats from https://en.wikipedia.org/wiki/World_Happiness_Report (2018)
 var head = [['ID', 'Country', 'Rank', 'Capital']];

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -58,7 +58,9 @@ interface BaseConfig {
     headStyles?: Styles,
     footStyles?: Styles,
     alternateRowStyles?: Styles,
-    columnStyles?: Styles,
+	columnStyles?: {
+		[key: string]: Styles;
+	};
 
     // Hooks
     didParseCell?: (data: CellHookData) => void;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -7,7 +7,7 @@ interface ColumnOption {
     dataKey?: string | number;
 }
 
-export type UserOptions = HTMLConfig | ContentConfig;
+export type UserOptions = HTMLConfig | ContentConfig | ColumnDataConfig;
 
 type Color = [number, number, number] | number | 'transparent' | false;
 type MarginPadding = number | { top?: number, right?: number, bottom?: number, left?: number }
@@ -73,6 +73,11 @@ interface ContentConfig extends BaseConfig {
     head?: SingleRowType | MultipleRowType
     foot?: SingleRowType | MultipleRowType
     body: MultipleRowType
+}
+
+interface ColumnDataConfig extends BaseConfig {
+	columns?: ColumnOption[];
+	body: object[];
 }
 
 interface HTMLConfig extends BaseConfig {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -58,9 +58,9 @@ interface BaseConfig {
     headStyles?: Styles,
     footStyles?: Styles,
     alternateRowStyles?: Styles,
-	columnStyles?: {
-		[key: string]: Styles;
-	};
+    columnStyles?: {
+        [key: string]: Styles;
+    };
 
     // Hooks
     didParseCell?: (data: CellHookData) => void;
@@ -76,8 +76,8 @@ interface ContentConfig extends BaseConfig {
 }
 
 interface ColumnDataConfig extends BaseConfig {
-	columns?: ColumnOption[];
-	body: object[];
+    columns?: ColumnOption[];
+    body: object[];
 }
 
 interface HTMLConfig extends BaseConfig {


### PR DESCRIPTION
- `columnStyles` should be dictionary of styles rather than a single style
- Support using auto table with `columns`, in which case body would be array of objects instead of array of arrays
- Updated typescript example to use `import` instead of require