### PR TITLE
 try fixing #469 

### DIFF
--- a/src/tableDrawer.ts
+++ b/src/tableDrawer.ts
@@ -69,7 +69,7 @@ function printFullRow(row: Row, isLastRow) {
                 // Note that this will cut cells with specified custom min height at page break
                 if (Array.isArray(cell.text) && cell.text.length > remainingLineCount) {
                     remainingTexts[column.dataKey] = cell.text.splice(remainingLineCount, cell.text.length);
-                    let rCellHeight = cell.height - remainingPageSpace;
+                    let rCellHeight = cell.height - Math.floor(cell.text.length * fontHeight);
                     if (rCellHeight > remainingRowHeight) {
                         remainingRowHeight = rCellHeight;
                     }


### PR DESCRIPTION
 try fixing #469 Row Content is NOT properly wrapped to corresponding cells in last rows (on few pages) and cutoff on next page.

I am not sure if I understand the issue correctly(especially the 'last row not wrapped correctly' part in description ), but the cutoff issue seems to be solved in this fix.