### PR TITLE
 try fixing #480 Cell border is not printed when a cell has rowspan at page break

### DIFF
--- a/src/tableDrawer.ts
+++ b/src/tableDrawer.ts
@@ -241,7 +241,7 @@ function printEmptyCellBorder(rowspanCellsCached) {
     let table: Table = state().table;
     table.cursor.x = table.margin('left');
     if (rowspanCellsCached !== undefined) {
-        _.forIn(rowspanCellsCached, (cell: any) => {
+        _.forIn(rowspanCellsCached, (cell: any, key) => {
             applyStyles(cell.styles);
 
             let fillStyle = getFillStyle(cell.styles);
@@ -249,8 +249,8 @@ function printEmptyCellBorder(rowspanCellsCached) {
                 state().doc.rect(table.cursor.x, table.cursor.y, cell.width, cell.height, fillStyle);
             }
             table.cursor.x += cell.width;
+            delete rowspanCellsCached[key];
         });
-        rowspanCellsCached = {};
     }
 }
 


### PR DESCRIPTION
this fix is a little bit verbose, but I just couldn't find a better way to do that. the basic idea is to cache the height of the cell which has rowspan at page break, and every time when a page is added, check the remain height then print the border.