### PR TITLE
Fixed blank first page issue when startY is string. Added more comprehensive "hidden" html element detection

### DIFF
--- a/src/htmlParser.ts
+++ b/src/htmlParser.ts
@@ -30,15 +30,31 @@ function parseTableSection(window, sectionElement, includeHidden, useCss) {
     if (!sectionElement) {
         return results;
     }
+
     for (let i = 0; i < sectionElement.rows.length; i++) {
         let row = sectionElement.rows[i];
         let resultRow: any = [];
         let rowStyles = useCss ? parseCss(row, state().scaleFactor(), ['cellPadding', 'lineWidth', 'lineColor']) : {};
         for (let i = 0; i < row.cells.length; i++) {
             let cell = row.cells[i];
-            let style = window.getComputedStyle(cell);
-            if (includeHidden || style.display !== 'none') {
+            if (includeHidden || !elementIsHidden(cell)) {
                 let cellStyles = useCss ? parseCss(cell, state().scaleFactor()) : {};
+
+                //filter any hidden elements from the contents!
+                if (!includeHidden) {
+                    const cellHiddenTotal = tagAllHiddenElements(cell, 0);
+
+                    if (cellHiddenTotal > 0) {
+                        //clone cell so we dont destroy the dom
+                        cell = cell.cloneNode(true);
+
+                        //remove all tagged elements!
+                        for (const element of cell.querySelectorAll('.jspdf-autotable-tag-hidden')) {
+                            element.parentElement.removeChild(element);
+                        }
+                    }
+                }
+
                 resultRow.push({
                     rowSpan: cell.rowSpan,
                     colSpan: cell.colSpan,
@@ -54,4 +70,34 @@ function parseTableSection(window, sectionElement, includeHidden, useCss) {
     }
 
     return results;
+}
+
+function elementIsHidden(element) {
+    const style = window.getComputedStyle(element);
+    return element.getAttribute('aria-hidden') || style.display === 'none' || style.visibility === 'hidden';
+}
+
+function tagAllHiddenElements(parent, count) {
+    //recursively look for hidden elements!
+    for(const child of parent.childNodes){
+        if (child.nodeType === Node.TEXT_NODE) {
+            continue;
+        }
+
+        //is it hidden?
+        if (elementIsHidden(child)) {
+            //hidden, so tag the element!
+            //we tag it like this because style computation in elementIsHidden() does not work when working on a clone of the cell that isnt currently in the dom.
+            //instead we just tag all hidden objects live in the dom and then the tag gets copied into the clone.
+            //from there we can just remove all matching elements with the tag!
+            child.className+=' jspdf-autotable-tag-hidden';
+            count++;
+        } else {
+            //not hidden so recurse further!
+            count = tagAllHiddenElements(child, count);
+        }
+    }
+
+    //chain
+    return count;
 }

--- a/src/inputParser.ts
+++ b/src/inputParser.ts
@@ -54,6 +54,8 @@ export function parseInput(args) {
 
     if (table.settings.startY === false) {
         delete table.settings.startY;
+    } else if (table.settings.startY !== null) {
+        table.settings.startY = parseInt(table.settings.startY);
     }
 
     const previous = state().doc.previousAutoTable;


### PR DESCRIPTION
Hey there I fixed this issue:
https://github.com/simonbengtsson/jsPDF-AutoTable/issues/507

And also added a feature to enable better "is hidden" detection on nested html elements. It uses the hidden html setting.