### PR TITLE
Fix Math.max with Array reduce

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -10,7 +10,7 @@ export function getStringWidth(text, styles) {
         .map(text => state().doc.getTextWidth(text))
         // Shave off a few digits for potential improvement in width calculation
         .map(val => Math.floor(val * 10000) / 10000)
-        .reduce(Math.max, 0);
+        .reduce((a, b) => Math.max(a, b), 0);
 
     const fontSize = styles.fontSize / state().scaleFactor();
     return widestLineWidth;


### PR DESCRIPTION
Fixes #564

[Math.max](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/max) can take more than two parameters, so using it with `Array.prototype.reduce` if the form `array.reduce(Math.max, 0)` with an array of two or more elements will result in a value of `NaN` because `reduce` will pass 4 parameters with the last one being the source array, for arrays with one element the last parameter will be the element itself (which is strange) so it won't cause a problem because the element is a number.