### PR TITLE
Fix tableWidth bug with minCellWidth (availableSpace)

### DIFF
--- a/src/widthCalculator.ts
+++ b/src/widthCalculator.ts
@@ -16,8 +16,7 @@ export function calculateWidths(table: Table) {
     }
 
     let copy = table.columns.slice(0);
-    let diffWidth = table.width - table.wrappedWidth;
-    distributeWidth(copy, diffWidth, table.wrappedWidth);
+    distributeWidth(copy, table.width, table.wrappedWidth);
 
     applyColSpans(table);
     fitContent(table);
@@ -152,7 +151,9 @@ function fitContent(table) {
     }
 }
 
-function distributeWidth(autoColumns, diffWidth, wrappedAutoColumnsWidth) {
+function distributeWidth(autoColumns, availableSpace, wrappedAutoColumnsWidth) {
+    let diffWidth = availableSpace - wrappedAutoColumnsWidth;
+
     for (let i = 0; i < autoColumns.length; i++) {
         let column = autoColumns[i];
         let ratio = column.wrappedWidth / wrappedAutoColumnsWidth;
@@ -172,8 +173,9 @@ function distributeWidth(autoColumns, diffWidth, wrappedAutoColumnsWidth) {
             // Add 1 to minWidth as linebreaks calc otherwise sometimes made two rows
             column.width = column.minWidth + 1 / state().scaleFactor();
             wrappedAutoColumnsWidth -= column.wrappedWidth;
+            availableSpace -= column.width;
             autoColumns.splice(i, 1);
-            distributeWidth(autoColumns, diffWidth, wrappedAutoColumnsWidth);
+            distributeWidth(autoColumns, availableSpace, wrappedAutoColumnsWidth);
             break;
         }
 


### PR DESCRIPTION
Fixes #566 

The problem :
when calculating columns widths, if `suggestedWidth` < `column.minWidth`, we remove `column` from the array and subtract `column.wrappedWidth` from `wrappedAutoColumnsWidth`, but we don't take in consideration the change in `diffWidth` which is based on how wide ALL columns (wrapped) compared to the `tableWidth`.

The fix :
we use `availableSpace` which get updated every time we remove a `column` from the calculation. then we calculated `diffWidth` based on that.