### PR TITLE
hookdata settings type to any

### DIFF
--- a/src/HookData.ts
+++ b/src/HookData.ts
@@ -4,7 +4,7 @@ import {Table, Cell, Row, Column} from "./models";
 export class HookData {
     table: Table;
     pageNumber: number;
-    settings: {};
+    settings: any;
     doc: any;
     cursor: { x: number, y: number };
 


### PR DESCRIPTION
fix the following typescript transpile error:

```
14:46 Property 'margin' does not exist on type '{}'.
    14 |             doc.text('Report', data.settings.margin.left, 18);
```