### PR TITLE
Fix for padding not being applied in Firefox when using the useCss option

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -31,7 +31,7 @@ declare class Table {
   pageStartX: number
   pageStartY: number
   finalY: number
-  readonly pageCount: number
+  get pageCount(): number
   styles: {
     styles: {}
     headStyles: {}
@@ -62,7 +62,7 @@ declare class Row {
   y: number
   pageNumber: number
   spansMultiplePages: boolean
-  readonly pageCount: number
+  get pageCount(): number
   constructor(raw: any, index: any, section: any)
   canEntireRowFit(height: any): boolean
   getMinimumRowHeight(): any
@@ -100,13 +100,13 @@ declare class Column {
 declare class HookData {
   table: Table
   pageNumber: number
-  settings: {}
+  settings: any
   doc: any
   cursor: {
     x: number
     y: number
   }
-  readonly pageCount: number
+  get pageCount(): number
   constructor()
 }
 declare class CellHookData extends HookData {

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -31,7 +31,7 @@ declare class Table {
   pageStartX: number
   pageStartY: number
   finalY: number
-  get pageCount(): number
+  readonly pageCount: number
   styles: {
     styles: {}
     headStyles: {}
@@ -62,7 +62,7 @@ declare class Row {
   y: number
   pageNumber: number
   spansMultiplePages: boolean
-  get pageCount(): number
+  readonly pageCount: number
   constructor(raw: any, index: any, section: any)
   canEntireRowFit(height: any): boolean
   getMinimumRowHeight(): any
@@ -100,13 +100,13 @@ declare class Column {
 declare class HookData {
   table: Table
   pageNumber: number
-  settings: any
+  settings: {}
   doc: any
   cursor: {
     x: number
     y: number
   }
-  get pageCount(): number
+  readonly pageCount: number
   constructor()
 }
 declare class CellHookData extends HookData {

--- a/dist/jspdf.plugin.autotable.js
+++ b/dist/jspdf.plugin.autotable.js
@@ -2131,7 +2131,12 @@ object-assign
           assign(
             'cellPadding',
             parsePadding(
-              style.padding,
+              [
+                style.paddingTop,
+                style.paddingRight,
+                style.paddingBottom,
+                style.paddingLeft,
+              ],
               style.fontSize,
               style.lineHeight,
               scaleFactor
@@ -2204,7 +2209,7 @@ object-assign
           var pxScaleFactor = 96 / (72 / scaleFactor)
           var linePadding =
             (parseInt(lineHeight) - parseInt(fontSize)) / scaleFactor / 2
-          var padding = val.split(' ').map(function(n) {
+          var padding = val.map(function(n) {
             return parseInt(n) / pxScaleFactor
           })
           padding = common_1.marginOrPadding(padding, 0)

--- a/dist/jspdf.plugin.autotable.min.js
+++ b/dist/jspdf.plugin.autotable.min.js
@@ -1482,13 +1482,18 @@ object-assign
                 if (!t) return null
                 var r = 96 / (72 / o),
                   i = (parseInt(n) - parseInt(e)) / o / 2,
-                  l = t.split(' ').map(function(t) {
+                  l = t.map(function(t) {
                     return parseInt(t) / r
                   })
                 ;(l = a.marginOrPadding(l, 0)), i > l.top && (l.top = i)
                 i > l.bottom && (l.bottom = i)
                 return l
-              })(n.padding, n.fontSize, n.lineHeight, e)
+              })(
+                [n.paddingTop, n.paddingRight, n.paddingBottom, n.paddingLeft],
+                n.fontSize,
+                n.lineHeight,
+                e
+              )
             ),
             i('lineWidth', parseInt(n.borderTopWidth || '') / (96 / 72) / e),
             i('lineColor', d(t, 'borderTopColor'))

--- a/src/cssParser.ts
+++ b/src/cssParser.ts
@@ -28,7 +28,17 @@ export function parseCss(element, scaleFactor, ignored: string[] = []) {
   assign('fontSize', parseInt(style.fontSize || '') / pxScaleFactor)
   assign(
     'cellPadding',
-    parsePadding(style.padding, style.fontSize, style.lineHeight, scaleFactor)
+    parsePadding(
+      [
+        style.paddingTop,
+        style.paddingRight,
+        style.paddingBottom,
+        style.paddingLeft,
+      ],
+      style.fontSize,
+      style.lineHeight,
+      scaleFactor
+    )
   )
 
   // style.borderWidth only works in chrome (borderTopWidth etc works in firefox and ie as well)
@@ -105,10 +115,9 @@ function parsePadding(val, fontSize, lineHeight, scaleFactor) {
   let linePadding =
     (parseInt(lineHeight) - parseInt(fontSize)) / scaleFactor / 2
 
-  let padding = val.split(' ').map(n => {
+  let padding = val.map(n => {
     return parseInt(n) / pxScaleFactor
   })
-
   padding = marginOrPadding(padding, 0)
   if (linePadding > padding.top) {
     padding.top = linePadding


### PR DESCRIPTION
I replaced style.padding with an array of the 4 paddingTop, right, bottom, left.
As the combined padding in getComputedStyle is only supported in chrome. 