### PR TITLE
Apply font-only styles for calculations

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -3,7 +3,7 @@ import state from './state'
 import { assign } from './polyfills'
 
 export function getStringWidth(text, styles) {
-  applyStyles(styles)
+  applyStyles(styles, true)
   const textArr: any = Array.isArray(text) ? text : [text]
 
   const widestLineWidth = textArr
@@ -75,20 +75,24 @@ export function applyUserStyles() {
   applyStyles(state().table.userStyles)
 }
 
-export function applyStyles(styles) {
-  let doc = state().doc
-  let styleModifiers = {
+export function applyStyles(styles, fontOnly = false) {
+  const doc = state().doc
+  const nonFontModifiers = {
     fillColor: doc.setFillColor,
     textColor: doc.setTextColor,
-    fontStyle: doc.setFontStyle,
     lineColor: doc.setDrawColor,
     lineWidth: doc.setLineWidth,
+  }
+  const styleModifiers = {
     font: doc.setFont,
     fontSize: doc.setFontSize,
+    fontStyle: doc.setFontStyle,
+    ...(fontOnly ? {} : nonFontModifiers),
   }
+
   Object.keys(styleModifiers).forEach(function (name) {
-    let style = styles[name]
-    let modifier = styleModifiers[name]
+    const style = styles[name]
+    const modifier = styleModifiers[name]
     if (typeof style !== 'undefined') {
       if (Array.isArray(style)) {
         modifier.apply(this, style)

--- a/src/widthCalculator.ts
+++ b/src/widthCalculator.ts
@@ -200,7 +200,7 @@ function fitContent(table) {
       let cell: Cell = row.cells[column.index]
       if (!cell) continue
 
-      applyStyles(cell.styles)
+      applyStyles(cell.styles, true)
       let textSpace = cell.width - cell.padding('horizontal')
       if (cell.styles.overflow === 'linebreak') {
         // Add one pt to textSpace to fix rounding error


### PR DESCRIPTION
Fixes #598

Apply font-only styles for text size calculations when calling `applyStyles()`.

When the dataset is large, `applyStyles` gets called large number of times on the first page for text calculations before drawing any cells, this causes the first page to be blank when `compress` option is `true` because of a bug in `jsPDF` v1.5.3.

To reduce the effect of this bug, we only apply font styles in this calculations (we only need font styles for it anyway).

Also apparently, either color styles is the ones that cause this bug or it has a much bigger effect  than font styles.

Before the fix, the bug happens for any table has more than 63k cells (~21k rows × 3 columns)

After the fix, I couldn't reach the limit when the bug happens, for a table with 1.5m cells (~500k rows × 3 columns) every thing works normally.

