### PR TITLE
Fix cell align with padding

### DIFF
--- a/src/tableDrawer.ts
+++ b/src/tableDrawer.ts
@@ -219,13 +219,15 @@ function printRow(row) {
     } else if (cell.styles.valign === 'bottom') {
       cell.textPos.y = table.cursor.y + cell.height - cell.padding('bottom')
     } else {
-      cell.textPos.y = table.cursor.y + cell.height / 2
+      const netHeight = cell.height - cell.padding('vertical')
+      cell.textPos.y = table.cursor.y + netHeight / 2 + cell.padding('top')
     }
 
     if (cell.styles.halign === 'right') {
       cell.textPos.x = cell.x + cell.width - cell.padding('right')
     } else if (cell.styles.halign === 'center') {
-      cell.textPos.x = cell.x + cell.width / 2
+      const netWidth = cell.width - cell.padding('horizontal')
+      cell.textPos.x = cell.x + netWidth / 2 + cell.padding('left')
     } else {
       cell.textPos.x = cell.x + cell.padding('left')
     }


### PR DESCRIPTION
Fixes #623 

Currently, halign: 'center' and valign: 'middle' centers the text absolutely regardless of the padding which is wrong, html takes padding into account and centers relative to the net size after the padding.

This PR fixes that to align with html behavior, here's the before & after :

Before :
![11](https://user-images.githubusercontent.com/5418859/78995037-cb2c7300-7b41-11ea-995c-8e506d3d3748.jpg)

After :
![22](https://user-images.githubusercontent.com/5418859/78995048-d089bd80-7b41-11ea-858a-5c41d953937c.jpg)

Here's the test setup file used :

[padding-align.zip](https://github.com/simonbengtsson/jsPDF-AutoTable/files/4461766/padding-align.zip)
_(extract in `examples/local`)_
