### PR TITLE
Fix setFont() called before setFontStyle()

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -84,9 +84,9 @@ export function applyStyles(styles, fontOnly = false) {
     lineWidth: doc.setLineWidth,
   }
   const styleModifiers = {
+    fontStyle: doc.setFontStyle,
     font: doc.setFont,
     fontSize: doc.setFontSize,
-    fontStyle: doc.setFontStyle,
     ...(fontOnly ? {} : nonFontModifiers),
   }
 


### PR DESCRIPTION
Fixes #632 

Bug introduced in version 3.4.1 where order of lines was changed
setFontStyle() should be called before setFont()