### PR TITLE
Use window as global object if this is undefined

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
     path: path.join(__dirname, './'),
     filename: '[name].js',
     libraryTarget: 'umd',
-    globalObject: 'this',
+    globalObject: 'typeof this !== \'undefined\' ? this : window',
   },
   module: {
     rules: [{ test: /\.ts$/, use: [{ loader: 'ts-loader' }] }],


### PR DESCRIPTION
"this" is undefined when using async module imports, but window is not