### PR TITLE
Fixed last row height recalculation in case of row is broken to next page

### DIFF
--- a/src/tableDrawer.ts
+++ b/src/tableDrawer.ts
@@ -81,6 +81,7 @@ function modifyRowToFit(
 ) {
   const cells: { [key: string]: Cell } = {}
   row.spansMultiplePages = true
+  row.height = 0
 
   let rowHeight = 0
 


### PR DESCRIPTION
Last page row breaking is not working properly in the last lib version because last row height is not recalculated. (Cell rect height is incorrect as the result).
See the example of generated document:

![image](https://user-images.githubusercontent.com/1121550/94352007-48a05d00-0068-11eb-9429-8d61b5e80ec7.png)
This behavior appeared after refactoring in this [commit](https://github.com/simonbengtsson/jsPDF-AutoTable/commit/87a5bd0954f7bb81e65fcb43adc81b1596c5705a#diff-031c1dcfc6d72fe46c173a047b1f9401L84).

(The height of breaking line must be reset so that it is recalculated below in the code with new corrected value).

---------------------------------------------
P.S. I also noticed that the [_Row.spansMultiplePages_ property](https://github.com/simonbengtsson/jsPDF-AutoTable/blob/master/src/models.ts#L164) is not used anymore.

---------------------------------------------
Thanks a lot for this great plugin!