### PR TITLE
Fixes/horizontal page break

### DIFF
--- a/examples/examples.js
+++ b/examples/examples.js
@@ -534,7 +534,7 @@ examples.custom = function () {
 }
 
 // Split columns - shows how the overflowed columns split into pages
-examples.splitPages = function () {
+examples.horizontalPageBreak = function () {
   var doc = new jsPDF('l')
 
   var head = headRows()

--- a/examples/examples.js
+++ b/examples/examples.js
@@ -546,7 +546,7 @@ examples.horizontalPageBreak = function () {
   head[0]['text'] = 'Text'
   var body = bodyRows(4)
   body.forEach(function (row) {
-    // row['text'] = faker.lorem.sentence(100);
+    row['text'] = faker.lorem.sentence(100);
     row['zipcode'] = faker.address.zipCode();
     row['country'] = faker.address.country();
     row['region'] = faker.address.state();
@@ -561,13 +561,6 @@ examples.horizontalPageBreak = function () {
     startY: 25,
     // split overflowing columns into pages
     horizontalPageBreak: true,
-    // Default for all columns
-    styles: { 
-      // overflow: 'ellipsize', 
-      cellWidth: 50 
-    },
-    // Override the default above for the text column
-    // columnStyles: { text: { cellWidth: 'auto' } },
   })
   return doc
 }

--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
             <li><a href="#themes">Themes</a></li>
             <li><a href="#nested">Nested</a></li>
             <li><a href="#custom">Custom style</a></li>
-            <li><a href="#splitPages">Split pages</a></li>
+            <li><a href="#horizontalPageBreak">Horizontal Page Break</a></li>
         </ul>
 
         <button id="download-btn" class="pure-button">Download PDF</button>

--- a/src/tablePrinter.ts
+++ b/src/tablePrinter.ts
@@ -1,9 +1,17 @@
+import { parseSpacing } from './common'
 import { DocHandler } from './documentHandler'
 import { Column, Table } from './models'
 
 export interface ColumnFitInPageResult {
   colIndexes: number[]
   columns: Column[]
+}
+
+const getPageAvailableWidth = (doc: DocHandler, table: Table) => {
+  const margins = parseSpacing(table.settings.margin, 0)
+  const availablePageWidth =
+    doc.pageSize().width - (margins.left + margins.right)
+  return availablePageWidth
 }
 
 // get columns can be fit into page
@@ -13,9 +21,7 @@ const getColumnsCanFitInPage = (
   config: any = {}
 ): ColumnFitInPageResult => {
   // get page width
-  const margins = table.settings.margin
-  const availablePageWidth =
-    doc.pageSize().width - (margins.left + margins.right)
+  const availablePageWidth = getPageAvailableWidth(doc, table)
   let remainingWidth = availablePageWidth
   const cols: number[] = []
   const columns: Column[] = []
@@ -26,6 +32,9 @@ const getColumnsCanFitInPage = (
     if (remainingWidth < colWidth) {
       // check if it's first column in the sequence then add it into result
       if (i === 0 || i === config.start) {
+        // this cell width is more than page width set it available pagewidth
+        /* table.columns[i].wrappedWidth = availablePageWidth
+        table.columns[i].minWidth = availablePageWidth */
         cols.push(i)
         columns.push(table.columns[i])
       }
@@ -67,4 +76,5 @@ const calculateAllColumnsCanFitInPage = (
 export default {
   getColumnsCanFitInPage,
   calculateAllColumnsCanFitInPage,
+  getPageAvailableWidth
 }


### PR DESCRIPTION
- in widthCalculator treating cellWidth auto as wrap
- inside wrap setting condition to prevent cellWidth be more than availablePageWidth
- removing custom cellWidth from example
