### PR TITLE
fix: fontStyle should accept custom font value

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,7 @@ export interface LineWidths {
 
 export interface Styles {
   font: 'helvetica' | 'times' | 'courier' | string
-  fontStyle: 'normal' | 'bold' | 'italic' | 'bolditalic'
+  fontStyle: 'normal' | 'bold' | 'italic' | 'bolditalic' | string
   overflow: 'linebreak' | 'ellipsize' | 'visible' | 'hidden' | Function
   fillColor: Color
   textColor: Color


### PR DESCRIPTION
Hello,

Thank you very much for this awesome library. The library is working very well in our projects. Recently we need to import some custom fontStyle to our project and found that the typing do not allow it. Hold that you can accept this patch to help us unblock the situation.