### PR TITLE
Fix new line issue when using in angular #757

### DIFF
--- a/src/htmlParser.ts
+++ b/src/htmlParser.ts
@@ -95,7 +95,7 @@ function parseCellContent(orgCell: HTMLTableCellElement) {
 
   // Preserve <br> tags as line breaks in the pdf
   cell.innerHTML = cell.innerHTML
-    .split('<br>')
+    .split(/\<br.*?\>/) //start with '<br' and ends with '>'.
     .map((part: string) => part.trim())
     .join('\n')
 


### PR DESCRIPTION
* Fix of #757 
* Now supports `<br> `, `<br />` , `<br customAttr="">` or any other things like `id` `class` inside `<br>` tag. it is  useful when working with angular or react