### PR TITLE
Fix skipping columns for horizontalPageBreakRepeat

### DIFF
--- a/src/tablePrinter.ts
+++ b/src/tablePrinter.ts
@@ -4,7 +4,8 @@ import { Column, Table } from './models'
 
 export interface ColumnFitInPageResult {
   colIndexes: number[]
-  columns: Column[]
+  columns: Column[],
+  lastIndex: number
 }
 
 const getPageAvailableWidth = (doc: DocHandler, table: Table) => {
@@ -66,7 +67,7 @@ const getColumnsCanFitInPage = (
     remainingWidth = remainingWidth - colWidth
     i++
   }
-  return { colIndexes: cols, columns }
+  return { colIndexes: cols, columns, lastIndex: i }
 }
 
 const calculateAllColumnsCanFitInPage = (
@@ -84,7 +85,7 @@ const calculateAllColumnsCanFitInPage = (
       start: index === 0 ? 0 : index,
     })
     if (result && result.columns && result.columns.length) {
-      index += result.columns.length
+      index = result.lastIndex
       allResults.push(result)
     } else {
       index++


### PR DESCRIPTION

`calculateAllColumnsCanFitInPage` function rely on returned fitted columns from `getColumnsCanFitInPage` to update `start` index.

https://github.com/simonbengtsson/jsPDF-AutoTable/blob/

let's say we have columns `[0, 1, 2, 3, 4] `and we want to repeat column `0` on every page
assume only columns` 0 and 1` fit to first page then `start=2`
if columns `0 and 2` could be fitted to second page then `start=4`
in the next iteration column `3` will be skipped!

Solution: rely on last returned index from `getColumnsCanFitInPage`