### PR TITLE
Fix table line not respecting table height with multiple tables across pages

### DIFF
--- a/src/tableDrawer.ts
+++ b/src/tableDrawer.ts
@@ -475,6 +475,7 @@ export function addPage(
   table.pageCount++
   cursor.x = margin.left
   cursor.y = margin.top
+  startPos.y = margin.top
 
   if (table.settings.showHead === 'everyPage') {
     table.head.forEach((row: Row) => printRow(doc, table, row, cursor, columns))


### PR DESCRIPTION
This PR fix the issue #805 and issue #691.

I've tested on the example that I've provided and it worked. It just needed to restart `startPos.y` after a page break. 

As I've restarted the value of `startPos.y` would it be necessary to restart the value of `startPos.x` too?