### PR TITLE
Fix infite loop on horizontal page break repeat example

### DIFF
--- a/examples/examples.js
+++ b/examples/examples.js
@@ -507,23 +507,23 @@ examples.horizontalPageBreak = function () {
   var doc = new jsPDF('l')
 
   var head = headRows()
-  head[0].region = 'Region';
-  head[0].country = 'Country';
-  head[0].zipcode = 'Zipcode';
-  head[0].phone = 'Phone';
+  head[0].region = 'Region'
+  head[0].country = 'Country'
+  head[0].zipcode = 'Zipcode'
+  head[0].phone = 'Phone'
   // head[0].timeZone = 'Timezone';
   head[0]['text'] = 'Text'
   var body = bodyRows(4)
   body.forEach(function (row) {
-    row['text'] = faker.lorem.sentence(100);
-    row['zipcode'] = faker.address.zipCode();
-    row['country'] = faker.address.country();
-    row['region'] = faker.address.state();
-    row['phone'] = faker.phone.phoneNumber();
+    row['text'] = faker.lorem.sentence(100)
+    row['zipcode'] = faker.address.zipCode()
+    row['country'] = faker.address.country()
+    row['region'] = faker.address.state()
+    row['phone'] = faker.phone.phoneNumber()
     // row['timeZone'] = faker.address.timeZone();
   })
 
-  doc.text("Split columns across pages if not fit in a single page", 14, 20)
+  doc.text('Split columns across pages if not fit in a single page', 14, 20)
   doc.autoTable({
     head: head,
     body: body,
@@ -541,23 +541,27 @@ examples.horizontalPageBreakRepeat = function () {
   var doc = new jsPDF('l')
 
   var head = headRows()
-  head[0].region = 'Region';
-  head[0].country = 'Country';
-  head[0].zipcode = 'Zipcode';
-  head[0].phone = 'Phone';
+  head[0].region = 'Region'
+  head[0].country = 'Country'
+  head[0].zipcode = 'Zipcode'
+  head[0].phone = 'Phone'
   // head[0].timeZone = 'Timezone';
   head[0]['text'] = 'Text'
   var body = bodyRows(4)
   body.forEach(function (row) {
-    row['text'] = faker.lorem.sentence(100);
-    row['zipcode'] = faker.address.zipCode();
-    row['country'] = faker.address.country();
-    row['region'] = faker.address.state();
-    row['phone'] = faker.phone.phoneNumber();
+    row['text'] = faker.lorem.sentence(15)
+    row['zipcode'] = faker.address.zipCode()
+    row['country'] = faker.address.country()
+    row['region'] = faker.address.state()
+    row['phone'] = faker.phone.phoneNumber()
     // row['timeZone'] = faker.address.timeZone();
   })
 
-  doc.text("Split columns across pages if not fit in a single page with a column repeated.", 14, 20)
+  doc.text(
+    'Split columns across pages if not fit in a single page with a column repeated.',
+    14,
+    20
+  )
   doc.autoTable({
     head: head,
     body: body,


### PR DESCRIPTION
Hi, currently if you try to see the "Horizontal Page Break Repeat" example on the demo site, it will cause an infinite loop and will break the user browser.

I was trying to figure out what was causing the infinite loop, but maybe it will take some time. So in the meantime I think it's better to not break the user browser and later fix this issue.