### PR TITLE
Remove unused imported variable

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { parseInput } from './inputParser'
 import { drawTable as _drawTable } from './tableDrawer'
 import { createTable as _createTable } from './tableCalculator'
 import { Table } from './models'
-import { CellHookData, HookData } from './HookData'
+import { CellHookData } from './HookData'
 import { Cell, Column, Row } from './models'
 
 export type autoTable = (options: UserOptions) => void


### PR DESCRIPTION
I know it's not that critical, but when I was looking at the codebase, I saw this unused imported variable.