### PR TITLE
fix: revert the draw color and line width after drawing the table

### DIFF
--- a/src/documentHandler.ts
+++ b/src/documentHandler.ts
@@ -24,6 +24,14 @@ export class DocHandler {
       fontSize: jsPDFDocument.internal.getFontSize(),
       fontStyle: jsPDFDocument.internal.getFont().fontStyle,
       font: jsPDFDocument.internal.getFont().fontName,
+      // 0 for versions of jspdf without getLineWidth
+      lineWidth: jsPDFDocument.getLineWidth
+        ? this.jsPDFDocument.getLineWidth()
+        : 0,
+      // Black for versions of jspdf without getDrawColor
+      lineColor: jsPDFDocument.getDrawColor
+        ? this.jsPDFDocument.getDrawColor()
+        : 0,
     }
   }
 

--- a/src/tableDrawer.ts
+++ b/src/tableDrawer.ts
@@ -10,8 +10,6 @@ export function drawTable(jsPDFDoc: jsPDFDocument, table: Table): void {
   const settings = table.settings
   const startY = settings.startY
   const margin = settings.margin
-  const originalDrawColor = jsPDFDoc.getDrawColor()
-  const originalLineWidth = jsPDFDoc.getLineWidth()
   const cursor = {
     x: margin.left,
     y: startY,
@@ -81,9 +79,6 @@ export function drawTable(jsPDFDoc: jsPDFDocument, table: Table): void {
   if (jsPDFDoc.autoTable) jsPDFDoc.autoTable.previous = table // Deprecated
 
   doc.applyStyles(doc.userStyles)
-
-  jsPDFDoc.setLineWidth(originalLineWidth)
-  jsPDFDoc.setDrawColor(originalDrawColor)
 }
 
 function printTableWithHorizontalPageBreak(


### PR DESCRIPTION
Fix #843 

Before
![before](https://user-images.githubusercontent.com/22689195/197928253-6c9d7edc-c0a5-466c-840a-e50388ee2693.png)

After
![after](https://user-images.githubusercontent.com/22689195/197928270-f75dab68-061b-421a-994d-02199af3e58a.png)
