### PR TITLE
Reset doc styles after new page header is printed

### DIFF
--- a/src/tableDrawer.ts
+++ b/src/tableDrawer.ts
@@ -494,6 +494,7 @@ export function addPage(
 
   if (table.settings.showHead === 'everyPage') {
     table.head.forEach((row: Row) => printRow(doc, table, row, cursor, columns))
+    doc.applyStyles(doc.userStyles)
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/simonbengtsson/jsPDF-AutoTable/issues/942

I came to this conclusion by stepping through with a debugger and noticed that the header row on subsequent pages has its styles applied (e.g. `textColor: 255`) but then is never reset for the body rows.

The first page rows doesn't have this problem because there is a `doc.applyStyles(doc.userStyles)` between the `printRow` of the first header and the first body row.

https://github.com/simonbengtsson/jsPDF-AutoTable/blob/f3d4de7172c4d71c1f801e4cae21fca464bb5ac6/src/tableDrawer.ts#L49-L62

It made sense for me to always reset the doc styles after the header row is inserted.