### PR TITLE
Fix resolution of types when using ModuleResolution: "NodeNext" in tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,14 @@
   "description": "Generate pdf tables with javascript (jsPDF plugin)",
   "main": "dist/jspdf.plugin.autotable.js",
   "exports": {
-    ".": "./dist/jspdf.plugin.autotable.js",
-    "./es": "./dist/jspdf.plugin.autotable.mjs"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/jspdf.plugin.autotable.js"
+    },
+    "./es": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/jspdf.plugin.autotable.mjs"
+    }
   },
   "types": "dist/index",
   "files": [


### PR DESCRIPTION
When using the `NodeNext` resolver the `types` field is ignored. Instead, the types should be defined under the `exports` field.