### PR TITLE
Prevent lineWidth object from filling the cell in black [#897]

### DIFF
--- a/examples/examples.js
+++ b/examples/examples.js
@@ -502,6 +502,117 @@ examples.custom = function () {
   return doc
 }
 
+// Custom style - shows how custom styles can be applied
+examples.borders = function () {
+  var doc = new jsPDF()
+  doc.autoTable({
+    head: headRows(),
+    body: bodyRows(3),
+    foot: [
+      [{
+        content: 'ID',
+        dataKey: 'id',
+        styles: {
+          fillColor: [255, 0, 0],
+          lineWidth: 1,
+          lineColor: 'black'
+        },
+      },
+      {
+        content: 'Name',
+        dataKey: 'name',
+        styles: {
+          fillColor: [0, 255, 0],
+        },
+      },
+      {
+        content: 'Email',
+        dataKey: 'email',
+        styles: {
+          fillColor: [0, 0, 255],
+          lineWidth: 2,
+          lineColor: 'yellow',
+        },
+      },
+      {
+        content: 'City',
+        dataKey: 'city',
+        styles: {
+          fillColor: [0, 255, 0],
+          lineWidth: 0.5
+        },
+      },
+      {
+        content: 'Sum',
+        dataKey: 'sum',
+        styles: {
+          textColor: 'white',
+          fillColor: [255, 0, 0],
+          lineColor: 'black',
+          lineWidth: {
+            right: 2,
+            bottom: 3,
+            top: 1,
+            left: 6
+          }
+        },
+      },]
+    ],
+    margin: { top: 40 },
+    theme: 'plain',
+    headStyles: {
+      fillColor: [241, 196, 15],
+      fontSize: 15,
+    },
+    footStyles: {
+      fillColor: [241, 196, 15],
+      fontSize: 15,
+    },
+    // Note that the "email" key below is the same as the column's dataKey used for
+    // the head and body rows. If your data is entered in array form instead you have to
+    // use the integer index instead i.e. `columnStyles: {5: {fillColor: [41, 128, 185], ...}}`
+    columnStyles: {
+      email: {
+        fontStyle: 'bold',
+      },
+      city: {
+        // The font file mitubachi-normal.js is included on the page and was created from mitubachi.ttf
+        // with https://rawgit.com/MrRio/jsPDF/master/fontconverter/fontconverter.html
+        // refer to https://github.com/MrRio/jsPDF#use-of-utf-8--ttf
+        font: 'mitubachi',
+      },
+      id: {
+        halign: 'right',
+      },
+    },
+    allSectionHooks: true,
+    // Use for customizing texts or styles of specific cells after they have been formatted by this plugin.
+    // This hook is called just before the column width and other features are computed.
+    didParseCell: function (data) {
+      if (data.row.section === 'head' && ['name','city'].includes(data.column.dataKey)) {
+        data.cell.styles.lineColor = 'black'
+        data.cell.styles.lineWidth = {
+          bottom: 1
+        }
+      }
+    },
+    // Use this to add content to each page that has the autoTable on it. This can be page headers,
+    // page footers and page numbers for example.
+    didDrawPage: function (data) {
+      doc.setFontSize(18)
+      doc.text('Custom borders showcase', data.settings.margin.left, 22)
+      doc.setFontSize(12)
+      doc.text(
+        'Borders are drawn just at the edge of the cell, which means that half of the border is in the cell and the other half is outside.',
+        data.settings.margin.left,
+        30,
+        {maxWidth: 180}
+      )
+    },
+  })
+  return doc
+}
+
 // Split columns - shows how the overflowed columns split into pages
 examples.horizontalPageBreak = function () {
   var doc = new jsPDF('l')

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
             padding: 10px;
             height: 100%;
         }
-        
+
         #wrapper {
             overflow: hidden;
             height: 100%;
@@ -79,7 +79,7 @@
             height: 100%;
             background: rgba(193, 193, 193, 1);
         }
-        
+
         .table {
             font-size: 14px;
         }
@@ -106,6 +106,7 @@
             <li><a href="#themes">Themes</a></li>
             <li><a href="#nested">Nested</a></li>
             <li><a href="#custom">Custom style</a></li>
+            <li><a href="#borders">Custom borders</a></li>
             <li><a href="#horizontalPageBreak">Horizontal Page Break</a></li>
             <li><a href="#horizontalPageBreakRepeat">Horizontal Page Break Repeat</a></li>
         </ul>

--- a/src/documentHandler.ts
+++ b/src/documentHandler.ts
@@ -105,7 +105,7 @@ export class DocHandler {
     return this.jsPDFDocument.splitTextToSize(text, size, opts)
   }
 
-  rect(x: number, y: number, width: number, height: number, fillStyle: string) {
+  rect(x: number, y: number, width: number, height: number, fillStyle: string | null) {
     return this.jsPDFDocument.rect(x, y, width, height, fillStyle)
   }
 


### PR DESCRIPTION
Completely reworked the way the border drawing works. It now takes into consideration the neighbouring borders to achieve 'sharp' edge. Borders are still centered on cell edge.

If `lineWidth: number` is provided, borders will be drawn using rectangle with stroke.

If `lineWidth: Partial<LineWidth>` is provided, borders will be drawn individually.

The tests passed, and from what I could see, all examples are working. I've also added example page with borders showcase - it may not be beautiful but showcases what can be done with the borders now.

Closes #897