### PR TITLE
Add `willDrawPage` hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,8 @@ You can customize the content and styling of the table by using the hooks. See t
 - `didParseCell: (HookData) => {}` - Called when the plugin finished parsing cell content. Can be used to override content or styles for a specific cell.
 - `willDrawCell: (HookData) => {}` - Called before a cell or row is drawn. Can be used to call native jspdf styling functions such as `doc.setTextColor` or change position of text etc before it is drawn.
 - `didDrawCell: (HookData) => {}` - Called after a cell has been added to the page. Can be used to draw additional cell content such as images with `doc.addImage`, additional text with `doc.addText` or other jspdf shapes.
-- `didDrawPage: (HookData) => {}` - Called after the plugin has finished drawing everything on a page. Can be used to add headers and footers with page numbers or any other content that you want on each page there is an autotable.
+- `didAddPage: (HookData) => {}` - Called after the plugin adds a page, before any content is added. Can be used to add headers or any other content that you want on each page there is an autotable.
+- `didDrawPage: (HookData) => {}` - Called after the plugin has finished drawing everything on a page. Can be used to add footers with page numbers or any other content that you want on each page there is an autotable.
 
 All hooks functions get passed an HookData object with information about the state of the table and cell. For example the position on the page, which page it is on etc.
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ You can customize the content and styling of the table by using the hooks. See t
 - `didParseCell: (HookData) => {}` - Called when the plugin finished parsing cell content. Can be used to override content or styles for a specific cell.
 - `willDrawCell: (HookData) => {}` - Called before a cell or row is drawn. Can be used to call native jspdf styling functions such as `doc.setTextColor` or change position of text etc before it is drawn.
 - `didDrawCell: (HookData) => {}` - Called after a cell has been added to the page. Can be used to draw additional cell content such as images with `doc.addImage`, additional text with `doc.addText` or other jspdf shapes.
-- `didAddPage: (HookData) => {}` - Called after the plugin adds a page, before any content is added. Can be used to add headers or any other content that you want on each page there is an autotable.
+- `willDrawPage: (HookData) => {}` - Called before starting to draw on a page. Can be used to add headers or any other content that you want on each page there is an autotable.
 - `didDrawPage: (HookData) => {}` - Called after the plugin has finished drawing everything on a page. Can be used to add footers with page numbers or any other content that you want on each page there is an autotable.
 
 All hooks functions get passed an HookData object with information about the state of the table and cell. For example the position on the page, which page it is on etc.

--- a/examples/examples.js
+++ b/examples/examples.js
@@ -189,7 +189,7 @@ examples['header-footer'] = function () {
   doc.autoTable({
     head: headRows(),
     body: bodyRows(40),
-    didAddPage: function (data) {
+    willDrawPage: function (data) {
       // Header
       doc.setFontSize(20)
       doc.setTextColor(40)

--- a/examples/examples.js
+++ b/examples/examples.js
@@ -189,7 +189,7 @@ examples['header-footer'] = function () {
   doc.autoTable({
     head: headRows(),
     body: bodyRows(40),
-    didDrawPage: function (data) {
+    didAddPage: function (data) {
       // Header
       doc.setFontSize(20)
       doc.setTextColor(40)
@@ -197,7 +197,8 @@ examples['header-footer'] = function () {
         doc.addImage(base64Img, 'JPEG', data.settings.margin.left, 15, 10, 10)
       }
       doc.text('Report', data.settings.margin.left + 15, 22)
-
+    },
+    didDrawPage: function (data) {
       // Footer
       var str = 'Page ' + doc.internal.getNumberOfPages()
       // Total page number plugin only available in jspdf v1.0+
@@ -509,54 +510,56 @@ examples.borders = function () {
     head: headRows(),
     body: bodyRows(3),
     foot: [
-      [{
-        content: 'ID',
-        dataKey: 'id',
-        styles: {
-          fillColor: [255, 0, 0],
-          lineWidth: 1,
-          lineColor: 'black'
+      [
+        {
+          content: 'ID',
+          dataKey: 'id',
+          styles: {
+            fillColor: [255, 0, 0],
+            lineWidth: 1,
+            lineColor: 'black',
+          },
         },
-      },
-      {
-        content: 'Name',
-        dataKey: 'name',
-        styles: {
-          fillColor: [0, 255, 0],
+        {
+          content: 'Name',
+          dataKey: 'name',
+          styles: {
+            fillColor: [0, 255, 0],
+          },
         },
-      },
-      {
-        content: 'Email',
-        dataKey: 'email',
-        styles: {
-          fillColor: [0, 0, 255],
-          lineWidth: 2,
-          lineColor: 'yellow',
+        {
+          content: 'Email',
+          dataKey: 'email',
+          styles: {
+            fillColor: [0, 0, 255],
+            lineWidth: 2,
+            lineColor: 'yellow',
+          },
         },
-      },
-      {
-        content: 'City',
-        dataKey: 'city',
-        styles: {
-          fillColor: [0, 255, 0],
-          lineWidth: 0.5
+        {
+          content: 'City',
+          dataKey: 'city',
+          styles: {
+            fillColor: [0, 255, 0],
+            lineWidth: 0.5,
+          },
         },
-      },
-      {
-        content: 'Sum',
-        dataKey: 'sum',
-        styles: {
-          textColor: 'white',
-          fillColor: [255, 0, 0],
-          lineColor: 'black',
-          lineWidth: {
-            right: 2,
-            bottom: 3,
-            top: 1,
-            left: 6
-          }
+        {
+          content: 'Sum',
+          dataKey: 'sum',
+          styles: {
+            textColor: 'white',
+            fillColor: [255, 0, 0],
+            lineColor: 'black',
+            lineWidth: {
+              right: 2,
+              bottom: 3,
+              top: 1,
+              left: 6,
+            },
+          },
         },
-      },]
+      ],
     ],
     margin: { top: 40 },
     theme: 'plain',
@@ -589,10 +592,13 @@ examples.borders = function () {
     // Use for customizing texts or styles of specific cells after they have been formatted by this plugin.
     // This hook is called just before the column width and other features are computed.
     didParseCell: function (data) {
-      if (data.row.section === 'head' && ['name','city'].includes(data.column.dataKey)) {
+      if (
+        data.row.section === 'head' &&
+        ['name', 'city'].includes(data.column.dataKey)
+      ) {
         data.cell.styles.lineColor = 'black'
         data.cell.styles.lineWidth = {
-          bottom: 1
+          bottom: 1,
         }
       }
     },
@@ -606,7 +612,7 @@ examples.borders = function () {
         'Borders are drawn just at the edge of the cell, which means that half of the border is in the cell and the other half is outside.',
         data.settings.margin.left,
         30,
-        {maxWidth: 180}
+        { maxWidth: 180 }
       )
     },
   })

--- a/src/config.ts
+++ b/src/config.ts
@@ -84,10 +84,15 @@ export interface UserOptions {
   }
 
   // Hooks
+  /** Called when the plugin finished parsing cell content. Can be used to override content or styles for a specific cell. */
   didParseCell?: CellHook
+  /** Called before a cell or row is drawn. Can be used to call native jspdf styling functions such as `doc.setTextColor` or change position of text etc before it is drawn. */
   willDrawCell?: CellHook
+  /** Called after a cell has been added to the page. Can be used to draw additional cell content such as images with `doc.addImage`, additional text with `doc.addText` or other jspdf shapes. */
   didDrawCell?: CellHook
-  didAddPage?: PageHook
+  /** Called before starting to draw on a page. Can be used to add headers or any other content that you want on each page there is an autotable. */
+  willDrawPage?: PageHook
+  /** Called after the plugin has finished drawing everything on a page. Can be used to add footers with page numbers or any other content that you want on each page there is an autotable. */
   didDrawPage?: PageHook
 }
 
@@ -95,25 +100,25 @@ export type ColumnInput =
   | string
   | number
   | {
-    header?: CellInput
-    title?: CellInput // deprecated (same as header)
-    footer?: CellInput
-    dataKey?: string | number
-    key?: string | number // deprecated (same as dataKey)
-  }
+      header?: CellInput
+      title?: CellInput // deprecated (same as header)
+      footer?: CellInput
+      dataKey?: string | number
+      key?: string | number // deprecated (same as dataKey)
+    }
 
 export type Color = [number, number, number] | number | string | false
 export type MarginPaddingInput =
   | number
   | number[]
   | {
-    top?: number
-    right?: number
-    bottom?: number
-    left?: number
-    horizontal?: number
-    vertical?: number
-  }
+      top?: number
+      right?: number
+      bottom?: number
+      left?: number
+      horizontal?: number
+      vertical?: number
+    }
 
 export interface CellDef {
   rowSpan?: number

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,6 +87,7 @@ export interface UserOptions {
   didParseCell?: CellHook
   willDrawCell?: CellHook
   didDrawCell?: CellHook
+  didAddPage?: PageHook
   didDrawPage?: PageHook
 }
 

--- a/src/inputParser.ts
+++ b/src/inputParser.ts
@@ -93,14 +93,14 @@ function parseHooks(
     didParseCell: [] as CellHook[],
     willDrawCell: [] as CellHook[],
     didDrawCell: [] as CellHook[],
-    didAddPage: [] as PageHook[],
+    willDrawPage: [] as PageHook[],
     didDrawPage: [] as PageHook[],
   }
   for (const options of allOptions) {
     if (options.didParseCell) result.didParseCell.push(options.didParseCell)
     if (options.willDrawCell) result.willDrawCell.push(options.willDrawCell)
     if (options.didDrawCell) result.didDrawCell.push(options.didDrawCell)
-    if (options.didAddPage) result.didAddPage.push(options.didAddPage)
+    if (options.willDrawPage) result.willDrawPage.push(options.willDrawPage)
     if (options.didDrawPage) result.didDrawPage.push(options.didDrawPage)
   }
 

--- a/src/inputParser.ts
+++ b/src/inputParser.ts
@@ -93,12 +93,14 @@ function parseHooks(
     didParseCell: [] as CellHook[],
     willDrawCell: [] as CellHook[],
     didDrawCell: [] as CellHook[],
+    didAddPage: [] as PageHook[],
     didDrawPage: [] as PageHook[],
   }
   for (const options of allOptions) {
     if (options.didParseCell) result.didParseCell.push(options.didParseCell)
     if (options.willDrawCell) result.willDrawCell.push(options.willDrawCell)
     if (options.didDrawCell) result.didDrawCell.push(options.didDrawCell)
+    if (options.didAddPage) result.didAddPage.push(options.didAddPage)
     if (options.didDrawPage) result.didDrawPage.push(options.didDrawPage)
   }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -17,15 +17,10 @@ export type PageHook = (data: HookData) => void | boolean
 export type CellHook = (data: CellHookData) => void | boolean
 
 export interface HookProps {
-  /** Called when the plugin finished parsing cell content. Can be used to override content or styles for a specific cell. */
   didParseCell: CellHook[]
-  /** Called before a cell or row is drawn. Can be used to call native jspdf styling functions such as `doc.setTextColor` or change position of text etc before it is drawn. */
   willDrawCell: CellHook[]
-  /** Called after a cell has been added to the page. Can be used to draw additional cell content such as images with `doc.addImage`, additional text with `doc.addText` or other jspdf shapes. */
   didDrawCell: CellHook[]
-  /** Called after the plugin adds a page, before any content is added. Can be used to add headers or any other content that you want on each page there is an autotable. */
-  didAddPage: PageHook[]
-  /** Called after the plugin has finished drawing everything on a page. Can be used to add footers with page numbers or any other content that you want on each page there is an autotable. */
+  willDrawPage: PageHook[]
   didDrawPage: PageHook[]
 }
 
@@ -146,8 +141,8 @@ export class Table {
       handler(new HookData(doc, this, cursor))
     }
   }
-  callDidAddPageHooks(doc: DocHandler, cursor: { x: number; y: number }) {
-    for (const handler of this.hooks.didAddPage) {
+  callWillDrawPageHooks(doc: DocHandler, cursor: { x: number; y: number }) {
+    for (const handler of this.hooks.willDrawPage) {
       handler(new HookData(doc, this, cursor))
     }
   }

--- a/src/models.ts
+++ b/src/models.ts
@@ -17,9 +17,15 @@ export type PageHook = (data: HookData) => void | boolean
 export type CellHook = (data: CellHookData) => void | boolean
 
 export interface HookProps {
+  /** Called when the plugin finished parsing cell content. Can be used to override content or styles for a specific cell. */
   didParseCell: CellHook[]
+  /** Called before a cell or row is drawn. Can be used to call native jspdf styling functions such as `doc.setTextColor` or change position of text etc before it is drawn. */
   willDrawCell: CellHook[]
+  /** Called after a cell has been added to the page. Can be used to draw additional cell content such as images with `doc.addImage`, additional text with `doc.addText` or other jspdf shapes. */
   didDrawCell: CellHook[]
+  /** Called after the plugin adds a page, before any content is added. Can be used to add headers or any other content that you want on each page there is an autotable. */
+  didAddPage: PageHook[]
+  /** Called after the plugin has finished drawing everything on a page. Can be used to add footers with page numbers or any other content that you want on each page there is an autotable. */
   didDrawPage: PageHook[]
 }
 
@@ -137,6 +143,11 @@ export class Table {
   callEndPageHooks(doc: DocHandler, cursor: { x: number; y: number }) {
     doc.applyStyles(doc.userStyles)
     for (const handler of this.hooks.didDrawPage) {
+      handler(new HookData(doc, this, cursor))
+    }
+  }
+  callDidAddPageHooks(doc: DocHandler, cursor: { x: number; y: number }) {
+    for (const handler of this.hooks.didAddPage) {
       handler(new HookData(doc, this, cursor))
     }
   }

--- a/src/tableDrawer.ts
+++ b/src/tableDrawer.ts
@@ -31,14 +31,10 @@ export function drawTable(jsPDFDoc: jsPDFDocument, table: Table): void {
     settings.pageBreak === 'always' ||
     (settings.startY != null && minTableBottomPos > doc.pageSize().height)
   ) {
-    const didAddPage = nextPage(doc)
+    nextPage(doc)
     cursor.y = margin.top
-
-    // call didAddPage hooks before any content is added to the page
-    if (didAddPage) {
-      table.callDidAddPageHooks(doc, cursor)
-    }
   }
+  table.callWillDrawPageHooks(doc, cursor)
 
   const startPos = assign({}, cursor)
 
@@ -93,10 +89,8 @@ function printTableWithHorizontalPageBreak(
   cursor: { x: number; y: number }
 ) {
   // calculate width of columns and render only those which can fit into page
-  const allColumnsCanFitResult: ColumnFitInPageResult[] = tablePrinter.calculateAllColumnsCanFitInPage(
-    doc,
-    table
-  )
+  const allColumnsCanFitResult: ColumnFitInPageResult[] =
+    tablePrinter.calculateAllColumnsCanFitInPage(doc, table)
 
   allColumnsCanFitResult.map(
     (colsAndIndexes: ColumnFitInPageResult, index: number) => {
@@ -535,7 +529,7 @@ export function addPage(
 
   const margin = table.settings.margin
   addTableBorder(doc, table, startPos, cursor)
-  const didAddPage = nextPage(doc)
+  nextPage(doc)
   table.pageNumber++
   table.pageCount++
   cursor.x = margin.left
@@ -543,9 +537,7 @@ export function addPage(
   startPos.y = margin.top
 
   // call didAddPage hooks before any content is added to the page
-  if (didAddPage) {
-    table.callDidAddPageHooks(doc, cursor)
-  }
+  table.callWillDrawPageHooks(doc, cursor)
 
   if (table.settings.showHead === 'everyPage') {
     table.head.forEach((row: Row) => printRow(doc, table, row, cursor, columns))
@@ -553,7 +545,6 @@ export function addPage(
   }
 }
 
-/** Remember to call the didAddPage hooks afterwards! */
 function nextPage(doc: DocHandler) {
   const current = doc.pageNumber()
   doc.setPage(current + 1)


### PR DESCRIPTION
Adds a `willDrawPage` hook. This makes it possible to add a page header _before_ content is added, which lets you avoid text selection like this:

https://github.com/simonbengtsson/jsPDF-AutoTable/assets/11315492/444bb5e0-83e8-4305-8d97-4924e2a702aa

## Notes

1. The `callEndPageHooks` function calls `doc.applyStyles(doc.userStyles)` before running the handlers. I don't know whether that would also be needed in `callWillDrawPageHooks`
2. I don't think the hook runs for the deprecated `autoTableAddPage()`