### PR TITLE
Use `body` instead of `allRows()` for `pageBreak: 'avoid'

### DIFF
--- a/src/tableDrawer.ts
+++ b/src/tableDrawer.ts
@@ -19,7 +19,7 @@ export function drawTable(jsPDFDoc: jsPDFDocument, table: Table): void {
   let minTableBottomPos = startY + margin.bottom + sectionsHeight
 
   if (settings.pageBreak === 'avoid') {
-    const rows = table.allRows()
+    const rows = table.body
     const tableHeight = rows.reduce((acc, row) => acc + row.height, 0)
 
     minTableBottomPos += tableHeight


### PR DESCRIPTION
Prevents header and footer heights to be included twice 
Fixes #976