### PR TITLE
Fix #966 - hex fillColor together with lineWidth causes invalid arguments for rect fn

### DIFF
--- a/examples/examples.js
+++ b/examples/examples.js
@@ -564,8 +564,11 @@ examples.borders = function () {
     margin: { top: 40 },
     theme: 'plain',
     headStyles: {
-      fillColor: [241, 196, 15],
+      fillColor: '#f1c40f',
       fontSize: 15,
+      lineWidth: {
+        top: 1
+      }
     },
     footStyles: {
       fillColor: [241, 196, 15],
@@ -599,6 +602,13 @@ examples.borders = function () {
         data.cell.styles.lineColor = 'black'
         data.cell.styles.lineWidth = {
           bottom: 1,
+        }
+      }
+      if (data.row.section === "body" && data.row.index === 1 && data.cell === data.row.cells[1]) {
+        data.cell.styles.fillColor = '#f1c40f' // cell background color
+        data.cell.styles.lineColor = 'red' // cell border color
+        data.cell.styles.lineWidth = {
+          bottom: 1, // only bottom border will be painted
         }
       }
     },

--- a/src/documentHandler.ts
+++ b/src/documentHandler.ts
@@ -105,7 +105,20 @@ export class DocHandler {
     return this.jsPDFDocument.splitTextToSize(text, size, opts)
   }
 
-  rect(x: number, y: number, width: number, height: number, fillStyle: string | null) {
+  /**
+   * Adds a rectangle to the PDF
+   * @param x Coordinate (in units declared at inception of PDF document) against left edge of the page
+   * @param y Coordinate (in units declared at inception of PDF document) against upper edge of the page
+   * @param width Width (in units declared at inception of PDF document)
+   * @param height Height (in units declared at inception of PDF document)
+   * @param fillStyle A string specifying the painting style or null. Valid styles include: 'S' [default] - stroke, 'F' - fill, and 'DF' (or 'FD') - fill then stroke. In "compat" API mode, a null value postpones setting the style so that a shape may be composed using multiple method calls. The last drawing method call used to define the shape should not have a null style argument. **In "advanced" API mode this parameter is deprecated.**
+   */
+  rect(x: number, y: number, width: number, height: number, fillStyle: 'S' | 'F' | 'DF' | 'FD' | null) {
+    if (!['S', 'F', 'DF', 'FD', null].some((v) => v === fillStyle)) {
+      throw new TypeError(
+        `Invalid value '${fillStyle}' passed to rect. Allowed values are: 'S', 'F', 'DF', 'FD', null`
+      )
+    }
     return this.jsPDFDocument.rect(x, y, width, height, fillStyle)
   }
 

--- a/src/tableDrawer.ts
+++ b/src/tableDrawer.ts
@@ -400,7 +400,7 @@ function drawCellBorders(doc: DocHandler, cell: Cell, cursor: Pos) {
  * @param doc
  * @param cell
  * @param cursor
- * @param fillColor - `false` for transparent, `string` for color, other types will use "F" from jsPDF.rect
+ * @param fillColor - passed to getFillStyle; `false` will map to transparent, `truthy` values to 'F' from jsPDF.rect
  */
 function drawCellBackground(
   doc: DocHandler,
@@ -408,9 +408,8 @@ function drawCellBackground(
   cursor: Pos,
   fillColor: Color
 ) {
-  const cellFillColor =
-    fillColor === false ? null : typeof fillColor !== 'string' ? 'F' : fillColor
-  doc.rect(cell.x, cursor.y, cell.width, cell.height, cellFillColor)
+  const fillStyle = getFillStyle(0, fillColor)
+  doc.rect(cell.x, cursor.y, cell.width, cell.height, fillStyle)
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/simonbengtsson/jsPDF-AutoTable/issues/966