### PR TITLE
Add support for repeating multiple columns using horizontalPageBreakRepeat

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -70,8 +70,8 @@ export interface UserOptions {
   html?: string | HTMLTableElement
   columns?: ColumnInput[]
   horizontalPageBreak?: boolean
-  // column data key to repeat if horizontalPageBreak = true
-  horizontalPageBreakRepeat?: string | number
+  // Column data key to repeat if horizontalPageBreak = true
+  horizontalPageBreakRepeat?: string[] | number[] | string | number
 
   // Styles
   styles?: Partial<Styles>

--- a/src/models.ts
+++ b/src/models.ts
@@ -38,7 +38,7 @@ export interface Settings {
   tableLineWidth: number
   tableLineColor: Color
   horizontalPageBreak?: boolean
-  horizontalPageBreakRepeat?: string | number | null
+  horizontalPageBreakRepeat?: string | number | string[] | number[] | null
 }
 
 export type StyleProp =


### PR DESCRIPTION
Hi. I have added a feature to support repeating multiple columns using the `horizontalPageBreakRepat` option. It accepts now `string[] | number[] | string | number` type which **DOESN'T** make any breaking changes.

After a positive review, I will add a new example to `examples.js` file.

Please let me know if you have any suggestions or questions.

Fixes #911