### PR TITLE
Add support for lineHeightFactor

### DIFF
--- a/src/autoTableText.ts
+++ b/src/autoTableText.ts
@@ -12,10 +12,12 @@ export default function (
   doc: jsPDFDocument
 ) {
   styles = styles || {}
-  const FONT_ROW_RATIO = 1.15
+  const PHYSICAL_LINE_HEIGHT = 1.15
 
   const k = doc.internal.scaleFactor
   const fontSize = doc.internal.getFontSize() / k
+  const lineHeightFactor = doc.getLineHeightFactor ? doc.getLineHeightFactor() : PHYSICAL_LINE_HEIGHT
+  const lineHeight = fontSize * lineHeightFactor
 
   const splitRegex = /\r\n|\r|\n/g
   let splitText: string | string[] = ''
@@ -31,12 +33,12 @@ export default function (
   }
 
   // Align the top
-  y += fontSize * (2 - FONT_ROW_RATIO)
+  y += fontSize * (2 - PHYSICAL_LINE_HEIGHT)
 
   if (styles.valign === 'middle')
-    y -= (lineCount / 2) * fontSize * FONT_ROW_RATIO
+    y -= (lineCount / 2) * lineHeight
   else if (styles.valign === 'bottom')
-    y -= lineCount * fontSize * FONT_ROW_RATIO
+    y -= lineCount * lineHeight
 
   if (styles.halign === 'center' || styles.halign === 'right') {
     let alignSize = fontSize
@@ -49,7 +51,7 @@ export default function (
           x - doc.getStringUnitWidth(splitText[iLine]) * alignSize,
           y
         )
-        y += fontSize * FONT_ROW_RATIO
+        y += lineHeight
       }
       return doc
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,5 @@
 import { CellHook, PageHook } from './models'
 
-/**
- * Ratio between font size and font height. The number comes from jspdf's source code
- */
-export const FONT_ROW_RATIO = 1.15
-
 export interface LineWidths {
   bottom: number
   top: number

--- a/src/documentHandler.ts
+++ b/src/documentHandler.ts
@@ -172,6 +172,15 @@ export class DocHandler {
     return this.jsPDFDocument.internal.scaleFactor
   }
 
+  get lineHeightFactor(): number {
+    const doc = this.jsPDFDocument
+    return doc.getLineHeightFactor ? doc.getLineHeightFactor() : 1.15
+  }
+
+  getLineHeight(fontSize: number): number {
+    return (fontSize / this.scaleFactor()) * this.lineHeightFactor
+  }
+
   pageNumber(): number {
     const pageInfo = this.jsPDFDocument.internal.getCurrentPageInfo()
     if (!pageInfo) {

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,7 +2,6 @@ import {
   CellInput,
   Color,
   ColumnInput,
-  FONT_ROW_RATIO,
   HtmlRowInput,
   RowInput,
   Styles,
@@ -216,10 +215,9 @@ export class Row {
     return columns.reduce((acc: number, column: Column) => {
       const cell = this.cells[column.index]
       if (!cell) return 0
-      const fontHeight =
-        (cell.styles.fontSize / doc.scaleFactor()) * FONT_ROW_RATIO
+      const lineHeight = doc.getLineHeight(cell.styles.fontSize)
       const vPadding = cell.padding('vertical')
-      const oneRowHeight = vPadding + fontHeight
+      const oneRowHeight = vPadding + lineHeight
       return oneRowHeight > acc ? oneRowHeight : acc
     }, 0)
   }
@@ -292,10 +290,11 @@ export class Cell {
     return { x, y }
   }
 
-  getContentHeight(scaleFactor: number) {
+  // TODO (v4): replace parameters with only (lineHeight)
+  getContentHeight(scaleFactor: number, lineHeightFactor: number = 1.15) {
     const lineCount = Array.isArray(this.text) ? this.text.length : 1
-    const fontHeight = (this.styles.fontSize / scaleFactor) * FONT_ROW_RATIO
-    const height = lineCount * fontHeight + this.padding('vertical')
+    const lineHeight = (this.styles.fontSize / scaleFactor) * lineHeightFactor
+    const height = lineCount * lineHeight + this.padding('vertical')
     return Math.max(height, this.styles.minCellHeight)
   }
 

--- a/src/tableDrawer.ts
+++ b/src/tableDrawer.ts
@@ -1,4 +1,4 @@
-import { Color, FONT_ROW_RATIO, LineWidths } from './config'
+import { Color, LineWidths } from './config'
 import { addTableBorder, getFillStyle } from './common'
 import { Cell, Column, Pos, Row, Table } from './models'
 import { DocHandler, jsPDFDocument } from './documentHandler'
@@ -153,10 +153,10 @@ function getRemainingLineCount(
   remainingPageSpace: number,
   doc: DocHandler
 ) {
-  const fontHeight = (cell.styles.fontSize / doc.scaleFactor()) * FONT_ROW_RATIO
+  const lineHeight = doc.getLineHeight(cell.styles.fontSize)
   const vPadding = cell.padding('vertical')
   const remainingLines = Math.floor(
-    (remainingPageSpace - vPadding) / fontHeight
+    (remainingPageSpace - vPadding) / lineHeight
   )
   return Math.max(0, remainingLines)
 }
@@ -198,7 +198,8 @@ function modifyRowToFit(
     }
 
     const scaleFactor = doc.scaleFactor()
-    cell.contentHeight = cell.getContentHeight(scaleFactor)
+    const lineHeightFactor = doc.lineHeightFactor
+    cell.contentHeight = cell.getContentHeight(scaleFactor, lineHeightFactor)
 
     if (cell.contentHeight >= remainingPageSpace) {
       cell.contentHeight = remainingPageSpace
@@ -208,7 +209,7 @@ function modifyRowToFit(
       row.height = cell.contentHeight
     }
 
-    remainderCell.contentHeight = remainderCell.getContentHeight(scaleFactor)
+    remainderCell.contentHeight = remainderCell.getContentHeight(scaleFactor, lineHeightFactor)
     if (remainderCell.contentHeight > rowHeight) {
       rowHeight = remainderCell.contentHeight
     }

--- a/src/widthCalculator.ts
+++ b/src/widthCalculator.ts
@@ -311,7 +311,7 @@ function fitContent(table: Table, doc: DocHandler) {
         }
       }
 
-      cell.contentHeight = cell.getContentHeight(doc.scaleFactor())
+      cell.contentHeight = cell.getContentHeight(doc.scaleFactor(), doc.lineHeightFactor)
 
       let realContentHeight = cell.contentHeight / cell.rowSpan
       if (


### PR DESCRIPTION
Fixes #767, #712, #753, #887, #802, #906

Reference PR : #754

## Before

![1](https://github.com/simonbengtsson/jsPDF-AutoTable/assets/5418859/4dddab93-654b-4460-91a2-c173206d8396)


## After

![2](https://github.com/simonbengtsson/jsPDF-AutoTable/assets/5418859/1c17e44c-d369-4971-bbb2-2d27b5f7303e)

## Example code

```js
const doc = new jsPDF();

table(10, 'LineHeightFactor: 1.15 \n(default)')

doc.setLineHeightFactor(0.9)
table(80, 'LineHeightFactor: 0.9')

doc.setLineHeightFactor(2.5)
table(150, 'LineHeightFactor: 2.5')

function table(x, title) {
  doc.text(title, x, 40)

  doc.autoTable({
    body: [
      ['text\non\nfour\nlines'],
      ['text on one line'],
      ['text on one line'],
    ],
    theme: 'grid',
    tableWidth: 50,
    startY: 50,
    styles: {
      textColor: 'black',
      fontSize: 18,
      lineColor: 0,
      // cellPadding: 0,
    },
    margin: {left: x}
  })
}
```
