### PR TITLE
Fix lineWidth object bug with fillColor: null

### DIFF
--- a/src/documentHandler.ts
+++ b/src/documentHandler.ts
@@ -111,14 +111,12 @@ export class DocHandler {
    * @param y Coordinate (in units declared at inception of PDF document) against upper edge of the page
    * @param width Width (in units declared at inception of PDF document)
    * @param height Height (in units declared at inception of PDF document)
-   * @param fillStyle A string specifying the painting style or null. Valid styles include: 'S' [default] - stroke, 'F' - fill, and 'DF' (or 'FD') - fill then stroke. In "compat" API mode, a null value postpones setting the style so that a shape may be composed using multiple method calls. The last drawing method call used to define the shape should not have a null style argument. **In "advanced" API mode this parameter is deprecated.**
+   * @param fillStyle A string specifying the painting style or null. Valid styles include: 'S' [default] - stroke, 'F' - fill, and 'DF' (or 'FD') - fill then stroke.
    */
-  rect(x: number, y: number, width: number, height: number, fillStyle: 'S' | 'F' | 'DF' | 'FD' | null) {
-    if (!['S', 'F', 'DF', 'FD', null].some((v) => v === fillStyle)) {
-      throw new TypeError(
-        `Invalid value '${fillStyle}' passed to rect. Allowed values are: 'S', 'F', 'DF', 'FD', null`
-      )
-    }
+  rect(x: number, y: number, width: number, height: number, fillStyle: 'S' | 'F' | 'DF' | 'FD') {
+    // null is excluded from fillStyle possible values because it isn't needed
+    // and is prone to bugs as it's used to postpone setting the style
+    // https://rawgit.com/MrRio/jsPDF/master/docs/jsPDF.html#rect
     return this.jsPDFDocument.rect(x, y, width, height, fillStyle)
   }
 


### PR DESCRIPTION
Fixes #1001

Refs : #730, #961, #978

`fillColor: null` caused cells to have full borders even when `lineWidth` is an object with partial borders.

This is caused by calling `rect()` to draw the background with `null` as `fillStyle` when `fillColor` is null :

https://github.com/simonbengtsson/jsPDF-AutoTable/blob/4c04f6a089b9dea919e84fee5fff649552cd49b8/src/tableDrawer.ts#L409-L410

## Reproduce code

```js
doc.autoTable({
  head: [['Name', 'Email', 'Country']],
  body: [
    ['David', 'david@example.com', 'Sweden'],
    ['Castille', 'castille@example.com', 'Spain'],
  ],
  theme: 'plain',
  styles: {
    // fillColor: null,
    lineColor: 0,
    lineWidth: {top: 0, bottom: 0.3, right: 0, left: 0},
  },
})
```

## Before

![image](https://github.com/simonbengtsson/jsPDF-AutoTable/assets/5418859/71d96180-e352-4b34-b83f-96a4a43b118e)

## After

![image](https://github.com/simonbengtsson/jsPDF-AutoTable/assets/5418859/e1b64d08-80de-45a8-ba36-429972516151)
