### PR TITLE
Support css parsing of individual borders sides

### DIFF
--- a/test/testCssParser.ts
+++ b/test/testCssParser.ts
@@ -25,6 +25,9 @@ describe('css parser', () => {
       paddingRight: '5px',
       paddingBottom: '5px',
       borderTopWidth: '2px',
+      borderBottomWidth: '2px',
+      borderLeftWidth: '2px',
+      borderRightWidth: '2px',
     }
     const pxScaleFactor = 96 / 72
     let element = table.insertRow()
@@ -42,8 +45,31 @@ describe('css parser', () => {
       5 / pxScaleFactor,
       'Cell padding'
     )
+    assert.equal(typeof styles.lineWidth, 'number', 'Line width number')
     assert.equal(styles.lineWidth, 2 / pxScaleFactor, 'Line width')
     assert(styles.fontSize === 16 / pxScaleFactor, 'No font size')
+  })
+
+  it('individual border sides', () => {
+    const style = {
+      borderRightWidth: '2px',
+      borderBottomWidth: '3px',
+      borderLeftWidth: '4px',
+    }
+    const pxScaleFactor = 96 / 72
+    const scaleFactor = 2
+    let element = table.insertRow()
+    for (const [prop, value] of Object.entries(style)) {
+      element.style[prop] = value
+    }
+    const styles = parseCss([], element, scaleFactor, element.style, dom.window)
+    assert.equal(typeof styles.lineWidth, 'object', 'Line width object')
+    assert.deepStrictEqual(styles.lineWidth, {
+      top: 0,
+      right: 2 / pxScaleFactor / scaleFactor,
+      bottom: 3 / pxScaleFactor / scaleFactor,
+      left: 4 / pxScaleFactor / scaleFactor,
+    }, 'Line widths')
   })
 
   it('minimal styles', () => {


### PR DESCRIPTION
Fixes #915

Individual borders sides (`lineWidth` as an object) was introduced in #730 but support was never added to the css parser so only `borderTopWidth` was used to set `lineWidth` as a number, this PR adds the missing support.

---

<details><summary>Example code (border-bottom)</summary>

```html
<!doctype html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>Test PDF</title>
    <style>
      body {
        margin: 0;
        display: flex;
        flex-direction: column;
        height: 100vh;
      }
      #output {
        width: 100%;
        flex-grow: 1;
      }
      table {
        border-collapse: collapse;
        margin: 10px 60px;
      }
      td, th {
        text-align: center;
        border-bottom: solid 1px red;
      }
    </style>
  </head>

  <body>
    <table id="table">
      <thead>
        <th>Name</th>
        <th>Email</th>
        <th>Country</th>
      </thead>
      <tbody>
        <tr>
          <td>David</td>
          <td>david@example.com</td>
          <td>Sweden</td>
        </tr>
        <tr>
          <td>Castille</td>
          <td>castille@example.com</td>
          <td>Spain</td>
        </tr>
      </tbody>
    </table>
    <object id="output" type="application/pdf"></object>
    <script src="../libs/jspdf.umd.js"></script>
    <script src="../../dist/jspdf.plugin.autotable.js"></script>
    <script>
      const { jsPDF } = window.jspdf
      const doc = new jsPDF()
    </script>
    <!-- =============================================================================== -->
    <script>
      doc.autoTable({
        html: '#table',
        useCss: true,
      })
    </script>
    <!-- =============================================================================== -->
    <script>
      document.getElementById('output').data = doc.output('datauristring')
      console.log(doc.lastAutoTable)
    </script>
  </body>
</html>
```

</details> 

## Before

![image](https://github.com/simonbengtsson/jsPDF-AutoTable/assets/5418859/dc36545c-acc7-49f7-81f4-276acb4be2df)

---

<br>

## After

![image](https://github.com/simonbengtsson/jsPDF-AutoTable/assets/5418859/af3dd9d0-4b49-4bee-bcf8-01c2c1231a50)
