### PR TITLE
Fix ESM module detection configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "jspdf-autotable",
   "version": "3.8.1",
   "description": "Generate pdf tables with javascript (jsPDF plugin)",
-  "main": "dist/jspdf.plugin.autotable.js",
+  "main": "dist/jspdf.plugin.autotable.mjs",
   "module": "dist/jspdf.plugin.autotable.mjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "default": "./dist/jspdf.plugin.autotable.js"
+      "default": "./dist/jspdf.plugin.autotable.mjs"
     },
     "./es": {
       "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -2,21 +2,11 @@
   "name": "jspdf-autotable",
   "version": "3.8.1",
   "description": "Generate pdf tables with javascript (jsPDF plugin)",
-  "main": "dist/jspdf.plugin.autotable.mjs",
+  "main": "dist/jspdf.plugin.autotable.js",
   "module": "dist/jspdf.plugin.autotable.mjs",
   "browser": "dist/jspdf.plugin.autotable.mjs",
-  "type": "module",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/jspdf.plugin.autotable.mjs"
-    },
-    "./es": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/jspdf.plugin.autotable.mjs"
-    }
-  },
-  "types": "dist/index",
+  "typings": "dist/index.d.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "dist/*"
   ],

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Generate pdf tables with javascript (jsPDF plugin)",
   "main": "dist/jspdf.plugin.autotable.mjs",
   "module": "dist/jspdf.plugin.autotable.mjs",
+  "browser": "dist/jspdf.plugin.autotable.mjs",
   "type": "module",
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.8.1",
   "description": "Generate pdf tables with javascript (jsPDF plugin)",
   "main": "dist/jspdf.plugin.autotable.js",
+  "module": "dist/jspdf.plugin.autotable.mjs",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
Hello,

I made changes to package.json to make it compatible with Angular 17 and the new esbuild/vite bundler that the angular-cli is using.
I tried multiple configurations, but this last one is what also jsPDF is using and is working well with ESM modules.

https://github.com/parallax/jsPDF/blob/master/package.json

