### PR TITLE
[v4] Remove globalDefaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ autoTable(doc, {
 })
 ```
 
+If `willDrawCell` explicitly returned `false`, cell will be skipped and it won't be drawn, do this when you handle drawing the cell's border & content yourself inside `willDrawCell`.
+
 ## API
 
 - `const table = autoTable(doc, { /* options */ })`

--- a/examples/examples.js
+++ b/examples/examples.js
@@ -401,7 +401,6 @@ examples.custom = function () {
         halign: 'right',
       },
     },
-    allSectionHooks: true,
     // Use for customizing texts or styles of specific cells after they have been formatted by this plugin.
     // This hook is called just before the column width and other features are computed.
     didParseCell: function (data) {
@@ -558,7 +557,6 @@ examples.borders = function () {
         halign: 'right',
       },
     },
-    allSectionHooks: true,
     // Use for customizing texts or styles of specific cells after they have been formatted by this plugin.
     // This hook is called just before the column width and other features are computed.
     didParseCell: function (data) {

--- a/src/documentHandler.ts
+++ b/src/documentHandler.ts
@@ -1,7 +1,5 @@
 import { Table } from './models'
-import { Color, Styles, UserOptions } from './config'
-
-let globalDefaults: UserOptions = {}
+import { Color, Styles } from './config'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type jsPDFConstructor = any
@@ -140,14 +138,6 @@ export class DocHandler {
 
   getFontList(): { [key: string]: string[] | undefined } {
     return this.jsPDFDocument.getFontList()
-  }
-
-  getGlobalOptions(): UserOptions {
-    return globalDefaults || {}
-  }
-
-  getDocumentOptions(): UserOptions {
-    return this.jsPDFDocument.__autoTableDocumentDefaults || {}
   }
 
   pageSize(): { width: number; height: number } {

--- a/src/inputValidator.ts
+++ b/src/inputValidator.ts
@@ -1,20 +1,13 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { UserOptions } from './config'
 
-export default function (
-  global: UserOptions,
-  document: UserOptions,
-  current: UserOptions,
-) {
-  for (const options of [global, document, current] as any) {
-    if (options && typeof options !== 'object') {
-      console.error(
-        'The options parameter should be of type object, is: ' + typeof options,
-      )
-    }
-    if (options.startY && typeof options.startY !== 'number') {
-      console.error('Invalid value for startY option', options.startY)
-      delete options.startY
-    }
+export function validateOptions(options: UserOptions) {
+  if (options && typeof options !== 'object') {
+    console.error(
+      'The options parameter should be of type object, is: ' + typeof options,
+    )
+  }
+  if (options.startY && typeof options.startY !== 'number') {
+    console.error('Invalid value for startY option', options.startY)
+    delete options.startY
   }
 }

--- a/src/tableDrawer.ts
+++ b/src/tableDrawer.ts
@@ -34,7 +34,7 @@ export function drawTable(jsPDFDoc: jsPDFDocument, table: Table): void {
     nextPage(doc)
     cursor.y = margin.top
   }
-  table.callWillDrawPageHooks(doc, cursor)
+  table.callWillDrawPageHook(doc, cursor)
 
   const startPos = assign({}, cursor)
 
@@ -71,7 +71,7 @@ export function drawTable(jsPDFDoc: jsPDFDocument, table: Table): void {
   }
 
   addTableBorder(doc, table, startPos, cursor)
-  table.callEndPageHooks(doc, cursor)
+  table.callEndPageHook(doc, cursor)
 
   table.finalY = cursor.y
 
@@ -414,7 +414,7 @@ function printRow(
     cell.x = cursor.x
     cell.y = cursor.y
 
-    const result = table.callCellHooks(
+    const result = table.callCellHook(
       doc,
       table.hooks.willDrawCell,
       cell,
@@ -422,6 +422,7 @@ function printRow(
       column,
       cursor,
     )
+    // Skip cell if hook explicitly returned false
     if (result === false) {
       cursor.x += column.width
       continue
@@ -444,7 +445,7 @@ function printRow(
       doc.getDocument(),
     )
 
-    table.callCellHooks(doc, table.hooks.didDrawCell, cell, row, column, cursor)
+    table.callCellHook(doc, table.hooks.didDrawCell, cell, row, column, cursor)
 
     cursor.x += column.width
   }
@@ -588,7 +589,7 @@ export function addPage(
 
   // Add user content just before adding new page ensure it will
   // be drawn above other things on the page
-  table.callEndPageHooks(doc, cursor)
+  table.callEndPageHook(doc, cursor)
 
   const margin = table.settings.margin
   addTableBorder(doc, table, startPos, cursor)
@@ -598,8 +599,8 @@ export function addPage(
   cursor.y = margin.top
   startPos.y = margin.top
 
-  // call didAddPage hooks before any content is added to the page
-  table.callWillDrawPageHooks(doc, cursor)
+  // call didAddPage hook before any content is added to the page
+  table.callWillDrawPageHook(doc, cursor)
 
   if (table.settings.showHead === 'everyPage') {
     table.head.forEach((row: Row) => printRow(doc, table, row, cursor, columns))

--- a/src/widthCalculator.ts
+++ b/src/widthCalculator.ts
@@ -72,8 +72,7 @@ function calculate(doc: DocHandler, table: Table) {
     for (const column of table.columns) {
       const cell = row.cells[column.index]
       if (!cell) continue
-      const hooks = table.hooks.didParseCell
-      table.callCellHooks(doc, hooks, cell, row, column, null)
+      table.callCellHook(doc, table.hooks.didParseCell, cell, row, column, null)
 
       const padding = cell.padding('horizontal')
       cell.contentWidth = getStringWidth(cell.text, cell.styles, doc) + padding


### PR DESCRIPTION
Hooks internally were arrays to combine hooks from options & globalDefaults, with the removal of globalDefaults, no need to keep then in arrays.