### PR TITLE
Rewrite width options and distribution algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Checkout more examples in [examples.js](examples) which is also the source code 
 - Major: Only the `autoTable(doc, {...})` usage style is now supported and `doc.autoTable({...})` has been removed (see usage section above. Read more: #997)
 - Setting default options has been removed and can be replaced by keeping track of this state yourself
 - Removed old deprecations
+- The value `'wrap'` of `cellWidth` and `tableWidth` has been renamed to `'max-content'`
 
 ## Options
 
@@ -121,8 +122,9 @@ autoTable(doc, {
 - `overflow: 'linebreak'|'ellipsize'|'visible'|'hidden' = 'linebreak'`
 - `fillColor: Color? = null`
 - `textColor: Color? = 20`
-- `cellWidth: 'auto'|'wrap'|number = 'auto'`
-- `minCellWidth: number? = 10`
+- `cellWidth: 'auto'|'min-content'|'max-content'|number = 'auto'`
+- `minCellWidth: 'auto'|'min-content'|'max-content'|number = 'auto'` (`'auto'` = 10pt for columns with `'auto'` cellWidth, 0 otherwise)
+- `maxCellWidth: 'auto'|'min-content'|'max-content'|number = 'auto'`
 - `minCellHeight: number = 0`
 - `halign: 'left'|'center'|'right' = 'left'`
 - `valign: 'top'|'middle'|'bottom' = 'top'`
@@ -187,9 +189,9 @@ autoTable(doc, {
 - `margin: Margin = 40`
 - `pageBreak: 'auto'|'avoid'|'always'` If set to `avoid` the plugin will only split a table onto multiple pages if table height is larger than page height.
 - `rowPageBreak: 'auto'|'avoid' = 'auto'` If set to `avoid` the plugin will only split a row onto multiple pages if row height is larger than page height.
-- `tableWidth: 'auto'|'wrap'|number = 'auto'`
-- `showHead: 'everyPage'|'firstPage'|'never' = 'everyPage''`
-- `showFoot: 'everyPage'|'lastPage'|'never' = 'everyPage''`
+- `tableWidth: 'auto'|'min-content'|'max-content'|'fit-content'|number = 'auto'` Option `'fit-content'` is similar to `'max-content'` but limited to the page width.
+- `showHead: 'everyPage'|'firstPage'|'never' = 'everyPage'`
+- `showFoot: 'everyPage'|'lastPage'|'never' = 'everyPage'`
 - `tableLineWidth: number = 0`
 - `tableLineColor: Color = 200` The table line/border color
 - `horizontalPageBreak: boolean = false` To split/break the table into multiple pages if the given table width exceeds the page width

--- a/examples/examples.js
+++ b/examples/examples.js
@@ -70,6 +70,99 @@ examples.minimal = function () {
   return doc
 }
 
+// Width options - shows how to use the different width options
+examples.width = function () {
+  const doc = new jsPDF()
+
+  const head = headRows()
+  head[0]['text'] = 'Text'
+  const body = bodyRows(2)
+  body.forEach(function (row) {
+    row['text'] = faker.lorem.sentence(10)
+  })
+
+  let table
+
+  doc.text("Auto width (default)", 14, 20)
+  table = autoTable(doc, {
+    head: head,
+    body: body,
+    startY: 25,
+  })
+  doc.text(
+    "cellWidth: 'max-content' except for the text column",
+    14,
+    table.finalY + 10,
+  )
+  table = autoTable(doc, {
+    head: head,
+    body: body,
+    startY: table.finalY + 15,
+    // Default for all columns
+    styles: { cellWidth: 'max-content' },
+    // Override the default above for the text column
+    columnStyles: { text: { cellWidth: 'auto' } },
+  })
+  doc.text(
+    "tableWidth: 'min-content'",
+    14,
+    table.finalY + 10,
+  )
+  table = autoTable(doc, {
+    head: head,
+    body: body,
+    startY: table.finalY + 15,
+    tableWidth: 'min-content',
+  })
+  doc.text(
+    "tableWidth: 'max-content'",
+    14,
+    table.finalY + 10,
+  )
+  table = autoTable(doc, {
+    head: head,
+    body: body,
+    startY: table.finalY + 15,
+    tableWidth: 'max-content',
+  })
+  doc.addPage()
+  doc.text(
+    "Limit maxCellWidth to 'max-content' except for the email column",
+    14,
+    20,
+  )
+  const columnsWithoutText = table.columns.slice(0, -1).map(c => c.raw)
+  for (let i = 0; i < 3; i++) {
+    table = autoTable(doc, {
+      head: head,
+      body: body,
+      columns: columnsWithoutText,
+      startY: (i ? table.finalY : 25),
+      styles: { maxCellWidth: 'max-content' },
+      columnStyles: { email: { maxCellWidth: 'auto' } },
+      tableWidth: ['auto', 150, 100][i],
+    })
+  }
+  doc.text(
+    "Limit minCellWidth to 'max-content' except for the email column",
+    14,
+    table.finalY + 10,
+  )
+  for (let i = 0; i < 3; i++) {
+    table = autoTable(doc, {
+      head: head,
+      body: body,
+      columns: columnsWithoutText,
+      startY: table.finalY + (i ? 0 : 15),
+      styles: { minCellWidth: 'max-content' },
+      columnStyles: { email: { minCellWidth: 'auto' } },
+      tableWidth: ['auto', 150, 100][i],
+    })
+  }
+
+  return doc
+}
+
 // Long data - shows how the overflow features looks and can be used
 examples.long = function () {
   const doc = new jsPDF('l')

--- a/examples/examples.js
+++ b/examples/examples.js
@@ -64,7 +64,7 @@ examples.minimal = function () {
   const doc = new jsPDF()
   autoTable(doc, {
     html: '.table',
-    tableWidth: 'wrap',
+    tableWidth: 'fit-content',
     styles: { cellPadding: 0.5, fontSize: 8 },
   })
   return doc
@@ -87,7 +87,7 @@ examples.long = function () {
     body: body,
     startY: 25,
     // Default for all columns
-    styles: { overflow: 'ellipsize', cellWidth: 'wrap' },
+    styles: { overflow: 'ellipsize', cellWidth: 'max-content' },
     // Override the default above for the text column
     columnStyles: { text: { cellWidth: 'auto' } },
   })

--- a/index.html
+++ b/index.html
@@ -99,6 +99,7 @@
             <ul class="menu">
                 <li><a href="#">Basic</a></li>
                 <li><a href="#minimal">Minimal</a></li>
+                <li><a href="#width">Width options</a></li>
                 <li><a href="#long">Long text</a></li>
                 <li><a href="#content">With content</a></li>
                 <li><a href="#multiple">Multiple tables</a></li>

--- a/src/common.ts
+++ b/src/common.ts
@@ -33,7 +33,7 @@ export function addTableBorder(
     doc.rect(
       startPos.x,
       startPos.y,
-      table.getWidth(doc.pageSize().width),
+      cursor.x - startPos.x,
       cursor.y - startPos.y,
       fillStyle,
     )
@@ -119,7 +119,7 @@ export function parseSpacing(
   return { top: value, right: value, bottom: value, left: value }
 }
 
-export function getPageAvailableWidth(doc: DocHandler, table: Table) {
-  const margins = parseSpacing(table.settings.margin, 0)
+export function getPageNetWidth(doc: DocHandler, table: Table) {
+  const margins = table.settings.margin
   return doc.pageSize().width - (margins.left + margins.right)
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,7 @@ export type OverflowType =
   | 'visible'
   | 'hidden'
   | ((text: string | string[], width: number) => string | string[])
-export type CellWidthType = 'auto' | 'wrap' | number
+export type CellWidthType = 'auto' | 'min-content' | 'max-content' | number
 
 export interface Styles {
   font: FontType
@@ -34,14 +34,15 @@ export interface Styles {
   lineColor: Color
   lineWidth: number | Partial<LineWidths>
   cellWidth: CellWidthType
+  minCellWidth: CellWidthType
+  maxCellWidth: CellWidthType
   minCellHeight: number
-  minCellWidth: number
 }
 
 export type ThemeType = 'striped' | 'grid' | 'plain' | null
 export type PageBreakType = 'auto' | 'avoid' | 'always'
 export type RowPageBreakType = 'auto' | 'avoid'
-export type TableWidthType = 'auto' | 'wrap' | number
+export type TableWidthType = CellWidthType | 'fit-content'
 export type ShowHeadType = 'everyPage' | 'firstPage' | 'never' | boolean
 export type ShowFootType = 'everyPage' | 'lastPage' | 'never' | boolean
 export type HorizontalPageBreakBehaviourType = 'immediately' | 'afterAllRows'
@@ -149,9 +150,10 @@ export function defaultStyles(scaleFactor: number): Styles {
     cellPadding: 5 / scaleFactor, // number or {top,left,right,left,vertical,horizontal}
     lineColor: 200,
     lineWidth: 0,
-    cellWidth: 'auto', // 'auto'|'wrap'|number
+    cellWidth: 'auto', // 'auto' | 'min-content' | 'max-content' | number
+    minCellWidth: 'auto', // 'auto' | 'min-content' | 'max-content' | number
+    maxCellWidth: 'auto', // 'auto' | 'min-content' | 'max-content' | number
     minCellHeight: 0,
-    minCellWidth: 0,
   }
 }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -298,7 +298,8 @@ export class Column {
   minWidth = 0
 
   /** The maximum width allowed for the column based on all cells and the constrains */
-  maxWidth = Infinity
+  // -1 will be converted to Infinity later
+  maxWidth = -1
 
   /** The final used width */
   width = 0

--- a/src/tablePrinter.ts
+++ b/src/tablePrinter.ts
@@ -1,4 +1,4 @@
-import { getPageAvailableWidth } from './common'
+import { getPageNetWidth } from './common'
 import { DocHandler } from './documentHandler'
 import { Column, Table } from './models'
 
@@ -14,8 +14,8 @@ function getColumnsCanFitInPage(
   table: Table,
   config: { start?: number } = {},
 ): ColumnFitInPageResult {
-  // Get page width
-  let remainingWidth = getPageAvailableWidth(doc, table)
+  // Get page width (allow for small tolerance to prevent unwanted page breaks)
+  let remainingWidth = getPageNetWidth(doc, table) + 1e-10
 
   // Get column data key to repeat
   const repeatColumnsMap = new Map<number, boolean>()
@@ -45,12 +45,12 @@ function getColumnsCanFitInPage(
       repeatColumnsMap.set(col.index, true)
       colIndexes.push(col.index)
       columns.push(table.columns[col.index])
-      remainingWidth -= col.wrappedWidth
+      remainingWidth -= col.width
     }
   })
 
   let first = true
-  let i = config?.start ?? 0 // make sure couter is initiated outside the loop
+  let i = config?.start ?? 0
   while (i < table.columns.length) {
     // Prevent duplicates
     if (repeatColumnsMap.has(i)) {
@@ -58,9 +58,9 @@ function getColumnsCanFitInPage(
       continue
     }
 
-    const colWidth = table.columns[i].wrappedWidth
+    const colWidth = table.columns[i].width
 
-    // Take at least one column even if it doesn't fit
+    // Take at least one column even if it doesn't fit to prevent infinite loops
     if (first || remainingWidth >= colWidth) {
       first = false
       colIndexes.push(i)

--- a/src/widthCalculator.ts
+++ b/src/widthCalculator.ts
@@ -95,7 +95,7 @@ function distributeInitialWidth(doc: DocHandler, table: Table): number {
       // This will change when colSpan width algorithm is implemented.
       if (cell.colSpan === 1) {
         column.minWidth = Math.max(column.minWidth, minCellWidth ?? 0)
-        column.maxWidth = Math.min(column.maxWidth, maxCellWidth ?? Infinity)
+        column.maxWidth = Math.max(column.maxWidth, maxCellWidth ?? -1)
 
         column.minContentWidth = Math.max(
           column.minContentWidth,
@@ -137,6 +137,10 @@ function distributeInitialWidth(doc: DocHandler, table: Table): number {
     // Column maxCellWidth (if set) overrides any maxCellWidth set on the cells
     if (maxWidth !== undefined) {
       column.maxWidth = maxWidth
+    }
+
+    if (column.maxWidth < 0) {
+      column.maxWidth = Infinity
     }
 
     let width = resolveWidthStyle(

--- a/src/widthCalculator.ts
+++ b/src/widthCalculator.ts
@@ -1,206 +1,386 @@
-import { getStringWidth, getPageAvailableWidth } from './common'
-import { Table, Cell, Column, Row } from './models'
+import { getStringWidth, getPageNetWidth } from './common'
+import { Table, Column, Row, Cell } from './models'
 import { DocHandler } from './documentHandler'
-import { Styles } from './config'
+import { TableWidthType, CellWidthType, Styles } from './config'
 
 /**
  * Calculate the column widths
  */
 export function calculateWidths(doc: DocHandler, table: Table) {
-  calculate(doc, table)
+  // Stage-1: Calculate and distribute the initial column widths
+  let excessWidth = distributeInitialWidth(doc, table)
+  const resizableColumns = table.columns.filter((column) => !column.isFixed)
 
-  const resizableColumns: Column[] = []
-  let initialTableWidth = 0
-
-  table.columns.forEach((column) => {
-    const customWidth = column.getMaxCustomCellWidth(table)
-    if (customWidth) {
-      // final column width
-      column.width = customWidth
-    } else {
-      // initial column width (will be resized)
-      column.width = column.wrappedWidth
-      resizableColumns.push(column)
-    }
-    initialTableWidth += column.width
-  })
-
-  // width difference that needs to be distributed
-  let resizeWidth = table.getWidth(doc.pageSize().width) - initialTableWidth
-
-  // first resize attempt: with respect to minReadableWidth and minWidth
-  if (resizeWidth) {
-    resizeWidth = resizeColumns(resizableColumns, resizeWidth, (column) =>
-      Math.max(column.minReadableWidth, column.minWidth),
-    )
+  // Stage-2: Distribute excess width on resizable columns with respect to minContentWidth and minWidth
+  if (excessWidth) {
+    excessWidth = distributeExcessWidth(resizableColumns, excessWidth)
   }
 
-  // second resize attempt: ignore minReadableWidth but respect minWidth
-  if (resizeWidth) {
-    resizeWidth = resizeColumns(
-      resizableColumns,
-      resizeWidth,
-      (column) => column.minWidth,
-    )
+  // Stage-3: Distribute any remaining negative excess width by ignoring minContentWidth
+  //          but respecting minWidth while trying to minimize word-breaking in columns
+  if (excessWidth < 0) {
+    excessWidth = shrinkColumnsBeyondMinContent(resizableColumns, excessWidth)
   }
 
-  resizeWidth = Math.abs(resizeWidth)
-  if (
-    !table.settings.horizontalPageBreak &&
-    resizeWidth > 0.1 / doc.scaleFactor()
-  ) {
+  // Report any remaining excess width (only when negative)
+  if (excessWidth < -1 / doc.scaleFactor() /* 1pt */) {
     // Table can't get smaller due to custom-width or minWidth restrictions
     // We can't really do much here. Up to user to for example
     // reduce font size, increase page size or remove custom cell widths
     // to allow more columns to be reduced in size
-    resizeWidth = resizeWidth < 1 ? resizeWidth : Math.round(resizeWidth)
+    excessWidth = Math.abs(excessWidth)
+    excessWidth = excessWidth < 1 ? excessWidth : Math.round(excessWidth)
     console.warn(
-      `Of the table content, ${resizeWidth} units width could not fit page`,
+      `[AutoTable] The table exceeds the allowed width by ${excessWidth} units, columns cannot get any smaller due to set restrictions.`,
     )
   }
+
+  // Calculate the final table width
+  const totalWidth = table.columns.reduce(
+    (total, column) => total + column.width,
+    0,
+  )
+
+  // Round floating-point summing inaccuracies to better reflect the defined tableWidth
+  table.width = Math.round(totalWidth * 1e10) / 1e10
 
   applyColSpans(table)
   fitContent(table, doc)
   applyRowSpans(table)
 }
 
-function calculate(doc: DocHandler, table: Table) {
-  const sf = doc.scaleFactor()
-  const horizontalPageBreak = table.settings.horizontalPageBreak
-  const availablePageWidth = getPageAvailableWidth(doc, table)
-  table.allRows().forEach((row) => {
+function distributeInitialWidth(doc: DocHandler, table: Table): number {
+  const pageNetWidth = getPageNetWidth(doc, table)
+  let sumInitialWidth = 0
+
+  // Start by processing cells Width styles, which are inherited from the columns if not set
+  for (const row of table.allRows()) {
     for (const column of table.columns) {
       const cell = row.cells[column.index]
       if (!cell) continue
+
       table.callCellHook(doc, table.hooks.didParseCell, cell, row, column, null)
 
       const padding = cell.padding('horizontal')
       cell.contentWidth = getStringWidth(cell.text, cell.styles, doc) + padding
 
+      // Calculate the minimum width required to fit the content in a readable manner
+      // (in which there's no word-breaking)
       const longestWordWidth = getStringWidth(
         cell.text.join(' ').split(/\s+/),
         cell.styles,
         doc,
       )
-      cell.minReadableWidth = longestWordWidth + cell.padding('horizontal')
+      cell.minContentWidth = longestWordWidth + padding
 
-      if (typeof cell.styles.cellWidth === 'number') {
-        cell.minWidth = cell.styles.cellWidth
-        cell.wrappedWidth = cell.styles.cellWidth
-      } else if (
-        cell.styles.cellWidth === 'wrap' ||
-        horizontalPageBreak === true
-      ) {
-        // cell width should not be more than available page width
-        if (cell.contentWidth > availablePageWidth) {
-          cell.minWidth = availablePageWidth
-          cell.wrappedWidth = availablePageWidth
-        } else {
-          cell.minWidth = cell.contentWidth
-          cell.wrappedWidth = cell.contentWidth
-        }
-      } else {
-        // auto
-        const defaultMinWidth = 10 / sf
-        cell.minWidth = cell.styles.minCellWidth || defaultMinWidth
-        cell.wrappedWidth = cell.contentWidth
-        if (cell.minWidth > cell.wrappedWidth) {
-          cell.wrappedWidth = cell.minWidth
-        }
-      }
-    }
-  })
+      const minCellWidth = resolveWidthStyle(
+        cell.styles.minCellWidth,
+        cell.minContentWidth,
+        cell.contentWidth,
+      )
+      const maxCellWidth = resolveWidthStyle(
+        cell.styles.maxCellWidth,
+        cell.minContentWidth,
+        cell.contentWidth,
+      )
 
-  table.allRows().forEach((row) => {
-    for (const column of table.columns) {
-      const cell = row.cells[column.index]
+      const cellWidth = resolveWidthStyle(
+        cell.styles.cellWidth,
+        cell.minContentWidth,
+        cell.contentWidth,
+      )
 
-      // For now we ignore the minWidth and wrappedWidth of colspan cells when calculating colspan widths.
-      // Could probably be improved upon however.
-      if (cell && cell.colSpan === 1) {
-        column.wrappedWidth = Math.max(column.wrappedWidth, cell.wrappedWidth)
-        column.minWidth = Math.max(column.minWidth, cell.minWidth)
-        column.minReadableWidth = Math.max(
-          column.minReadableWidth,
-          cell.minReadableWidth,
+      // TODO: colSpan
+      // For now we only aggregate widths of non colSpan cells
+      // This will change when colSpan width algorithm is implemented.
+      if (cell.colSpan === 1) {
+        column.minWidth = Math.max(column.minWidth, minCellWidth ?? 0)
+        column.maxWidth = Math.min(column.maxWidth, maxCellWidth ?? Infinity)
+
+        column.minContentWidth = Math.max(
+          column.minContentWidth,
+          cell.minContentWidth,
         )
-      } else {
-        // Respect cellWidth set in columnStyles even if there is no cells for this column
-        // or if the column only have colspan cells. Since the width of colspan cells
-        // does not affect the width of columns, setting columnStyles cellWidth enables the
-        // user to at least do it manually.
+        column.maxContentWidth = Math.max(
+          column.maxContentWidth,
+          cell.contentWidth,
+        )
 
-        // Note that this is not perfect for now since for example row and table styles are
-        // not accounted for
-        const columnStyles =
-          table.styles.columnStyles[column.dataKey] ||
-          table.styles.columnStyles[column.index] ||
-          {}
-        const cellWidth = columnStyles.cellWidth || columnStyles.minCellWidth
-        if (cellWidth && typeof cellWidth === 'number') {
-          column.minWidth = cellWidth
-          column.wrappedWidth = cellWidth
-        }
-      }
-
-      if (cell) {
-        // Make sure all columns get at least min width even though width calculations are not based on them
-        if (cell.colSpan > 1 && !column.minWidth) {
-          column.minWidth = cell.minWidth
-        }
-        if (cell.colSpan > 1 && !column.wrappedWidth) {
-          column.wrappedWidth = cell.minWidth
+        // Aggregate the width and mark the column as fixed if any of the non-colSpan cells has a defined width
+        if (cellWidth !== undefined) {
+          column.width = Math.max(column.width, cellWidth)
+          column.isFixed = true
         }
       }
     }
-  })
+  }
+
+  // Process columns styles last to take into account aggregated cells content widths
+  for (const column of table.columns) {
+    // TODO: Process colSpan cells here? <<
+
+    const columnStyles = column.getStyles(table.styles)
+
+    const minWidth = resolveWidthStyle(
+      columnStyles.minCellWidth,
+      column.minContentWidth,
+      column.maxContentWidth,
+    )
+    column.minWidth = Math.max(column.minWidth, minWidth ?? 0)
+
+    const maxWidth = resolveWidthStyle(
+      columnStyles.maxCellWidth,
+      column.minContentWidth,
+      column.maxContentWidth,
+    )
+
+    // Column maxCellWidth (if set) overrides any maxCellWidth set on the cells
+    if (maxWidth !== undefined) {
+      column.maxWidth = maxWidth
+    }
+
+    let width = resolveWidthStyle(
+      columnStyles.cellWidth,
+      column.minContentWidth,
+      column.maxContentWidth,
+    )
+
+    // Fixed column (column width is set)
+    if (width !== undefined) {
+      column.isFixed = true
+    }
+
+    // If column is still not fixed, inherit tableWidth if it's content-based
+    // this includes 'fit-content' which is similar to 'max-content' but limited to page width
+    if (!column.isFixed && typeof table.settings.tableWidth !== 'number') {
+      width = resolveWidthStyle(
+        table.settings.tableWidth,
+        column.minContentWidth,
+        column.maxContentWidth,
+      )
+    }
+
+    // In horizontalPageBreak mode, assign maxContentWidth (clamped to page width) to auto columns with no width
+    if (
+      table.settings.horizontalPageBreak &&
+      !column.isFixed &&
+      width === undefined
+    ) {
+      width = Math.min(column.maxContentWidth, pageNetWidth)
+    }
+
+    // Final clamped column width before excess width distribution
+    if (column.isFixed || width !== undefined) {
+      column.width = clampMinMax(
+        Math.max(column.width, width ?? 0),
+        column.minWidth,
+        column.maxWidth,
+      )
+    }
+
+    // Set default minCellWidth if not set (only for auto columns)
+    // this is to prevent shrinking auto columns to zero width later
+    if (
+      !(
+        column.isFixed ||
+        column.minWidth ||
+        typeof columnStyles.minCellWidth === 'number' ||
+        typeof table.styles.styles.minCellWidth === 'number'
+      )
+    ) {
+      column.minWidth = 10 / doc.scaleFactor() // 10pt
+    }
+
+    sumInitialWidth += column.width
+  }
+
+  // At this point we have :
+  // - Fixed columns that have received their final clamped width, as defined on the column or any of its cells.
+  // - Auto columns that have either:
+  //   - Inherited the tableWidth if it's content-based and received the appropriate clamped width.
+  //   - Received their clamped maxContentWidth when in horizontalPageBreak mode.
+  //   - If none of the above, they have not yet been assigned a width, which will happen in the next stage.
+
+  // Next we calculate the target table width and the excess width that will be distributed on auto columns
+  let targetWidth = 0
+
+  if (typeof table.settings.tableWidth === 'number') {
+    // Fixed table width
+    targetWidth = table.settings.tableWidth
+  } else if (table.settings.tableWidth === 'auto') {
+    if (table.settings.horizontalPageBreak) {
+      // In horizontalPageBreak mode, width should already be distributed
+      // just make sure it's not shorter than the page in 'auto' tableWidth mode
+      targetWidth = Math.max(sumInitialWidth, pageNetWidth)
+    } else {
+      // Table is stretched (or shrunk) to fit the page
+      targetWidth = pageNetWidth
+    }
+  } else if (table.settings.tableWidth === 'fit-content') {
+    if (table.settings.horizontalPageBreak) {
+      // In horizontalPageBreak mode, content width should already be distributed
+      targetWidth = sumInitialWidth
+    } else {
+      // Table width is the minimum of maxContentWidth and page width
+      targetWidth = Math.min(sumInitialWidth, pageNetWidth)
+    }
+  } else {
+    // Content-based table width should already be distributed on auto columns
+    // when they inherited tableWidth (min-content, max-content)
+    targetWidth = sumInitialWidth
+  }
+
+  // Excess width available for distribution, which could be:
+  // (+) positive (columns need to grow)
+  // (-) negative (columns need to shrink)
+  // (0) zero (table already has the desired width)
+  return targetWidth - sumInitialWidth
 }
 
 /**
- * Distribute resizeWidth on passed resizable columns
+ * Resolve width style to a value
  */
-export function resizeColumns(
-  columns: Column[],
-  resizeWidth: number,
-  getMinWidth: (column: Column) => number,
+function resolveWidthStyle(
+  WidthStyle: CellWidthType | TableWidthType | undefined,
+  minContentWidth: number,
+  maxContentWidth: number,
 ) {
-  const initialResizeWidth = resizeWidth
-  const sumWrappedWidth = columns.reduce(
-    (acc, column) => acc + column.wrappedWidth,
+  if (typeof WidthStyle === 'number') {
+    return WidthStyle
+  } else if (WidthStyle === 'min-content') {
+    return minContentWidth
+  } else if (WidthStyle === 'max-content' || WidthStyle === 'fit-content') {
+    return maxContentWidth
+  } else {
+    // auto
+    return undefined
+  }
+}
+
+/**
+ * Clamp a value by a minimum and a maximum limits
+ * (min overrides max)
+ */
+function clampMinMax(value: number, min = 0, max = Infinity): number {
+  // Process max first to ensure min overrides max (To be consistent with CSS)
+  return Math.max(Math.min(value, max), min)
+}
+
+/**
+ * Distribute excessWidth on given resizable columns based on maxContentWidth ratio
+ * with respect to minContentWidth and minWidth of each of the columns
+ */
+function distributeExcessWidth(columns: Column[], excessWidth: number): number {
+  const initialExcessWidth = excessWidth
+  const sumMaxContentWidth = columns.reduce(
+    (total, column) => total + column.maxContentWidth,
     0,
   )
 
-  for (let i = 0; i < columns.length; i++) {
-    const column = columns[i]
+  // Cannot distribute any width if there's no maxContentWidth to calculate the base ratio
+  if (sumMaxContentWidth === 0) return excessWidth
 
-    const ratio = column.wrappedWidth / sumWrappedWidth
-    const suggestedChange = initialResizeWidth * ratio
+  for (const column of columns) {
+    const ratio = column.maxContentWidth / sumMaxContentWidth
+    const suggestedChange = initialExcessWidth * ratio
     const suggestedWidth = column.width + suggestedChange
 
-    const minWidth = getMinWidth(column)
-    const newWidth = suggestedWidth < minWidth ? minWidth : suggestedWidth
+    const newWidth = clampMinMax(
+      Math.max(suggestedWidth, column.minContentWidth),
+      column.minWidth,
+      column.maxWidth,
+    )
 
-    resizeWidth -= newWidth - column.width
+    excessWidth -= newWidth - column.width
     column.width = newWidth
   }
 
-  resizeWidth = Math.round(resizeWidth * 1e10) / 1e10
-
-  // Run the resizer again if there's remaining width needs
-  // to be distributed and there're columns that can be resized
-  if (resizeWidth) {
+  // Continue running recursively until all the excess width has been distributed
+  // or there are no more columns that can be resized any further
+  if (Math.abs(excessWidth) > 1e-10) {
     const resizableColumns = columns.filter((column) => {
-      return resizeWidth < 0
-        ? column.width > getMinWidth(column) // check if column can shrink
-        : true // check if column can grow
+      return excessWidth < 0
+        ? column.width > Math.max(column.minWidth, column.minContentWidth) // check if column can shrink
+        : column.width < column.maxWidth // check if column can grow
     })
 
     if (resizableColumns.length) {
-      resizeWidth = resizeColumns(resizableColumns, resizeWidth, getMinWidth)
+      excessWidth = distributeExcessWidth(resizableColumns, excessWidth)
     }
   }
 
-  return resizeWidth
+  return excessWidth
+}
+
+/**
+ * Distribute negative excessWidth on given resizable columns when they're at their minContentWidth limit.
+ * Doing so will cause the columns to shrink beyond their minContentWidth causing definite word-break so this
+ * algorithm helps minimizing that by first shrinking the longest column and then moving to the next in size-order.
+ */
+function shrinkColumnsBeyondMinContent(
+  columns: Column[],
+  excessWidth: number,
+): number {
+  // Make sure this is used only for shrinking
+  if (excessWidth >= 0) return excessWidth
+
+  // Sort columns by width, from longest to shortest
+  columns.sort((a, b) => {
+    return a.width < b.width ? 1 : -1
+  })
+
+  // equalColumns will hold grouped columns that will shrink together to the same width.
+  // They will shrink down to the next column in queue then it will join them in the next round
+  const equalColumns: Column[] = []
+  distribute(true)
+
+  function distribute(pushNextColumn: boolean) {
+    const column = pushNextColumn ? columns.shift() : equalColumns[0]
+
+    // End the recursion when there're no more columns to work on
+    if (!column) return
+
+    if (pushNextColumn) equalColumns.push(column)
+
+    // Distribute the excess width on the grouped columns equally
+    const equalShare = excessWidth / equalColumns.length
+    let suggestedWidth = column.width + equalShare
+
+    // Limit shrinking to the width of the next column in queue
+    let nextLimitReached = false
+    if (columns.length) {
+      if (suggestedWidth < columns[0].width) {
+        suggestedWidth = columns[0].width
+        nextLimitReached = true
+      }
+    }
+
+    const constrainedColumns: number[] = []
+
+    // Shrink the grouped columns to the same width with respect to each minWidth
+    equalColumns.forEach((column, i) => {
+      const constrained = suggestedWidth < column.minWidth
+      const newWidth = constrained ? column.minWidth : suggestedWidth
+      excessWidth -= newWidth - column.width
+      column.width = newWidth
+      if (constrained) constrainedColumns.push(i)
+    })
+
+    // Removed any columns that reached their minWidth limit
+    if (constrainedColumns.length) {
+      for (const i of constrainedColumns.reverse()) {
+        equalColumns.splice(i, 1)
+      }
+      // Redistribute the excess width that was supposed to be given to the constrained columns
+      // before adding the next column in the queue as long as there're still columns in the group
+      return distribute(equalColumns.length == 0)
+    }
+
+    // Recursively run until all the excess width has been distributed (or there're no more columns)
+    if (nextLimitReached) distribute(true)
+  }
+
+  return excessWidth
 }
 
 function applyRowSpans(table: Table) {
@@ -290,24 +470,30 @@ function fitContent(table: Table, doc: DocHandler) {
 
       doc.applyStyles(cell.styles, true)
       const textSpace = cell.width - cell.padding('horizontal')
-      if (cell.styles.overflow === 'linebreak') {
-        // Add one pt to textSpace to fix rounding error
-        cell.text = doc.splitTextToSize(
-          cell.text,
-          textSpace + 1 / doc.scaleFactor(),
-          { fontSize: cell.styles.fontSize },
-        )
-      } else if (cell.styles.overflow === 'ellipsize') {
-        cell.text = ellipsize(cell.text, textSpace, cell.styles, doc, '...')
-      } else if (cell.styles.overflow === 'hidden') {
-        cell.text = ellipsize(cell.text, textSpace, cell.styles, doc, '')
-      } else if (typeof cell.styles.overflow === 'function') {
-        const result = cell.styles.overflow(cell.text, textSpace)
-        if (typeof result === 'string') {
-          cell.text = [result]
-        } else {
-          cell.text = result
+      if (cell.width) {
+        if (cell.styles.overflow === 'linebreak') {
+          // Add one pt to textSpace to fix rounding error
+          cell.text = doc.splitTextToSize(
+            cell.text,
+            textSpace + 1 / doc.scaleFactor(),
+            { fontSize: cell.styles.fontSize },
+          )
+        } else if (cell.styles.overflow === 'ellipsize') {
+          cell.text = ellipsize(cell.text, textSpace, cell.styles, doc, '...')
+        } else if (cell.styles.overflow === 'hidden') {
+          cell.text = ellipsize(cell.text, textSpace, cell.styles, doc, '')
+        } else if (typeof cell.styles.overflow === 'function') {
+          const result = cell.styles.overflow(cell.text, textSpace)
+          if (typeof result === 'string') {
+            cell.text = [result]
+          } else {
+            cell.text = result
+          }
         }
+      } else {
+        // Empty the cell if it has no width to prevent unwanted extra height
+        // otherwise it would require a line-height for each character in the cell
+        cell.text = ['']
       }
 
       cell.contentHeight = cell.getContentHeight(

--- a/test/testInputParser.ts
+++ b/test/testInputParser.ts
@@ -27,20 +27,7 @@ describe('input parser', () => {
     assert.equal(table.foot.length, 0)
     assert.equal(Object.keys(table.head[0].cells).length, 2)
     assert.equal(table.head[0].cells[0].text, 'test')
-    assert(table.head[0].cells[0].minWidth > 0)
-  })
-
-  it('minReadableWidth', () => {
-    const d = new jsPDF()
-    const input = parseInput(d, {
-      head: [['aaaa', 'aa', 'aaa']],
-      body: [['a', 'a', 'a']],
-    })
-    const table = createTable(d, input)
-    const cols = table.columns
-    assert(table.body[0].cells[0].minReadableWidth > 0)
-    assert(cols[0].minReadableWidth > cols[1].minReadableWidth)
-    assert(cols[1].minReadableWidth < cols[2].minReadableWidth)
+    assert(table.head[0].cells[0].contentWidth > 0)
   })
 
   it('object input', () => {
@@ -61,7 +48,7 @@ describe('input parser', () => {
     assert.equal(table.head[0].cells[0].text, 'ID')
   })
 
-  it('object input', () => {
+  it('object input two', () => {
     const d = new jsPDF()
     const input = parseInput(d, {
       head: [[{ content: 'test' }, 'test 2']],

--- a/test/testWidthCalculator.ts
+++ b/test/testWidthCalculator.ts
@@ -97,6 +97,69 @@ describe('width calculator', () => {
     assert.equal(cols[5].width, cols[5].minContentWidth, 'minCellWidth min-content')
   })
 
+  it('aggregated min & max width', () => {
+    const doc = new jsPDF()
+    const input = parseInput(doc, {
+      body: [
+        ['a', 'a', 'a', 'a'],
+        ['ab cd', 'ab cd', 'ab cd', 'ab cd'],
+        ['', '', '', ''],
+      ],
+      columnStyles: {
+        0: {},
+        1: {minCellWidth: 'min-content', maxCellWidth: 'max-content'},
+        2: {minCellWidth: 'max-content'},
+        3: {maxCellWidth: 'min-content'},
+      }
+    })
+    const table = createTable(doc, input)
+    const cols = table.columns
+    assert(cols[0].minWidth < cols[0].minContentWidth, 'minCellWidth auto')
+    assert.equal(cols[0].maxWidth, Infinity, 'maxCellWidth auto')
+    assert.equal(cols[1].minWidth, cols[1].minContentWidth, 'minCellWidth min-content')
+    assert.equal(cols[1].maxWidth, cols[1].maxContentWidth, 'maxCellWidth max-content')
+    assert.equal(cols[2].minWidth, cols[2].maxContentWidth, 'minCellWidth max-content')
+    assert.equal(cols[2].maxWidth, Infinity, 'maxCellWidth auto')
+    assert.equal(cols[3].maxWidth, cols[3].minContentWidth, 'maxCellWidth min-content')
+    assert(cols[3].minWidth < cols[3].minContentWidth, 'minCellWidth auto')
+
+    for (const col of cols) {
+      assert(col.minContentWidth > 0 && col.maxContentWidth > col.minContentWidth)
+      assert.equal(col.minContentWidth, table.body[1].cells[col.index].minContentWidth)
+      assert.equal(col.maxContentWidth, table.body[1].cells[col.index].contentWidth)
+      assert(col.width >= col.minWidth && col.width <= col.maxWidth)
+    }
+  })
+
+  it('aggregated min & max width - with styles', () => {
+    const doc = new jsPDF()
+    const input = parseInput(doc, {
+      head: [['a', 'a', 'ab cd']],
+      body: [
+        ['a', 'a', 'a'],
+        ['ab cd', 'ab cd', 'a'],
+        ['', '', ''],
+      ],
+      styles: {minCellWidth: 'min-content', maxCellWidth: 'max-content'},
+      columnStyles: {
+        0: {minCellWidth: 'auto', maxCellWidth: 'auto'},
+      }
+    })
+    const table = createTable(doc, input)
+    const cols = table.columns
+    for (const col of cols) {
+      assert(col.minContentWidth > 0 && col.maxContentWidth > col.minContentWidth)
+      if (col.index === 0) {
+        assert(col.minWidth < col.minContentWidth, 'minCellWidth auto')
+        assert.equal(col.maxWidth, Infinity, 'maxCellWidth auto')
+      } else {
+        assert.equal(col.minWidth, col.minContentWidth, 'minCellWidth min-content')
+        assert.equal(col.maxWidth, col.maxContentWidth, 'maxCellWidth max-content')
+      }
+      assert(col.width >= col.minWidth && col.width <= col.maxWidth)
+    }
+  })
+
   it('minimize word-break', () => {
     const doc = new jsPDF()
     const input = parseInput(doc, {
@@ -123,23 +186,24 @@ describe('width calculator', () => {
         [{content: '0', styles: {cellWidth: 20}}, {content: '1', styles: {minCellWidth: 110}}, '2', '3', '4'],
         ['0', '1', {content: '2', styles: {cellWidth: 5}}, {content: '3', styles: {maxCellWidth: 10}}, '4'],
         ['0', '1', '2', {content: '3', styles: {maxCellWidth: 20}}, '4'],
-        ['0', '1', '2', '3', {content: '4', styles: {maxCellWidth: 10}}],
+        ['0', '1', '2', '3', {content: '4', styles: {maxCellWidth: 20}}],
       ],
       columnStyles: {
         0: {cellWidth: 15},
         1: {minCellWidth: 105},
         2: {minCellWidth: 100},
-        4: {maxCellWidth: 20},
+        4: {maxCellWidth: 10},
       },
       tableWidth: 260,
     })
     const table = createTable(doc, input)
     const cols = table.columns
+    assert.equal(table.width, 260, 'tableWidth')
     assert.equal(cols[0].width, 20, 'cellWidth')
     assert.equal(cols[1].width, 110, 'minCellWidth')
     assert.equal(cols[2].width, 100, 'cellWidth on head')
-    assert.equal(cols[3].width, 10, 'maxCellWidth')
-    assert.equal(cols[4].width, 20, 'maxCellWidth on columnStyles should override cells')
+    assert.equal(cols[3].width, 20, 'maxCellWidth')
+    assert.equal(cols[4].width, 10, 'maxCellWidth on columnStyles should override cells')
   })
 
   it('reset column width', () => {

--- a/test/testWidthCalculator.ts
+++ b/test/testWidthCalculator.ts
@@ -1,159 +1,178 @@
-const assert = require('assert')
-import { resizeColumns } from '../src/widthCalculator'
-import { Column } from '../src/models'
+import { jsPDF } from 'jspdf'
+import { parseInput } from '../src/inputParser';
+import { createTable } from '../src/tableCalculator';
+import * as assert from 'assert'
 
-describe('calculator', () => {
-  describe('columns resizer', () => {
-    it('shrink: one column - no min', () => {
-      const col1 = new Column('col1', null, 0)
-      col1.width = 700
-      col1.wrappedWidth = 700
-      const resizeWidth = resizeColumns([col1], -700, () => 0)
-      assert.equal(col1.width, 0, 'width')
-      assert.equal(resizeWidth, 0, 'resizeWidth')
+function round(val: number) {
+  return Math.round(val * 1000) / 1000
+}
+
+describe('width calculator', () => {
+
+  it('minContentWidth & maxContentWidth', () => {
+    const d = new jsPDF()
+    const input = parseInput(d, {
+      head: [['abcd', 'ab cd', 'abc']],
+      body: [
+        ['ab cd', 'a', 'a'],
+        ['a', 'a', 'a'],
+      ],
+      styles: {fontSize: 10, fontStyle: 'normal'},
     })
+    const table = createTable(d, input)
+    const cols = table.columns
+    assert(cols[0].minContentWidth > 0)
+    assert(cols[0].minContentWidth > cols[1].minContentWidth)
+    assert(cols[1].minContentWidth < cols[2].minContentWidth)
+    assert(cols[0].maxContentWidth > 0)
+    assert(cols[0].minContentWidth < cols[0].maxContentWidth)
+    assert.equal(cols[0].maxContentWidth, cols[1].maxContentWidth)
+    assert(cols[1].maxContentWidth > cols[2].maxContentWidth)
+    assert.equal(cols[2].minContentWidth, cols[2].maxContentWidth)
+  })
 
-    it('shrink: one column - min', () => {
-      const col1 = new Column('col1', null, 0)
-      col1.width = 700
-      col1.wrappedWidth = 700
-      col1.minWidth = 200
-      const resizeWidth = resizeColumns([col1], -600, (col) => col.minWidth)
-      assert.equal(col1.width, 200, 'width')
-      assert.equal(resizeWidth, -100, 'resizeWidth')
+  it('grow relative to content', () => {
+    const doc = new jsPDF()
+    const row = ['abc', 'a', '', 'ab', 'abcd', 'ab', 'abc', 'ab cd']
+    const input = parseInput(doc, {
+      body: [row],
     })
+    const table = createTable(doc, input)
+    const cols = table.columns
+    for (let i = 0; i < cols.length; i++) {
+      for (let j = i+1; j < cols.length; j++) {
+        const w1 = cols[i].width
+        const w2 = cols[j].width
+        if (row[i].length === row[j].length) {
+          assert.equal(w1, w2, `equal width ${i}, ${j}`)
+        } else {
+          assert(row[i].length > row[j].length ? w1 > w2 : w1 < w2, `compare width ${i}, ${j}`)
+        }
+      }
+    }
+  })
 
-    it('shrink: two columns - no min', () => {
-      const w1 = 1200,
-        w2 = 400,
-        r = -500
-      const col1 = new Column('col1', null, 0)
-      col1.width = w1
-      col1.wrappedWidth = w1
-      const col2 = new Column('col2', null, 1)
-      col2.width = w2
-      col2.wrappedWidth = w2
-      const resizeWidth = resizeColumns([col1, col2], r, () => 0)
-      assert.equal(col1.width, w1 + r * (w1 / (w1 + w2)), 'col1 width')
-      assert.equal(col2.width, w2 + r * (w2 / (w1 + w2)), 'col2 width')
-      assert.equal(resizeWidth, 0, 'resizeWidth')
+  it('width options', () => {
+    const doc = new jsPDF()
+    const input = parseInput(doc, {
+      body: [Array(4).fill('abc def')],
+      columnStyles: {
+        0: {cellWidth: 10},
+        1: {cellWidth: 'min-content'},
+        2: {cellWidth: 'max-content'},
+      }
     })
+    const table = createTable(doc, input)
+    const cols = table.columns
+    assert.equal(cols[0].width, 10, 'fixed width')
+    assert.equal(cols[1].width, cols[1].minContentWidth, 'min-content')
+    assert(cols[1].minContentWidth > 0)
+    assert.equal(cols[2].width, cols[2].maxContentWidth, 'max-content')
+    assert(cols[2].maxContentWidth > 0)
+    assert(cols[2].maxContentWidth > cols[2].minContentWidth)
+    assert.equal(round(cols[3].width), round(table.width - (cols[0].width + cols[1].width + cols[2].width)), 'auto width')
+  })
 
-    it('shrink: two columns - min', () => {
-      const w1 = 1200,
-        w2 = 400,
-        r = -500
-      const col1 = new Column('col1', null, 0)
-      col1.width = w1
-      col1.wrappedWidth = w1
-      col1.minWidth = 900
-      const col2 = new Column('col2', null, 1)
-      col2.width = w2
-      col2.wrappedWidth = w2
-      col2.minWidth = 100
-      const resizeWidth = resizeColumns([col1, col2], r, (col) => col.minWidth)
-      assert.equal(col1.width, 900, 'col1 width')
-      assert.equal(col2.width, 200, 'col2 width')
-      assert.equal(resizeWidth, 0, 'resizeWidth')
+  it('minCellWidth & maxCellWidth', () => {
+    const doc = new jsPDF()
+    const input = parseInput(doc, {
+      body: [Array(6).fill('abc def')],
+      styles: {cellWidth: 50},
+      columnStyles: {
+        0: {},
+        1: {minCellWidth: 60},
+        2: {maxCellWidth: 40},
+        3: {minCellWidth: 60, maxCellWidth: 55},
+        4: {maxCellWidth: 'max-content'},
+        5: {cellWidth: 1, minCellWidth: 'min-content'},
+      }
     })
+    const table = createTable(doc, input)
+    const cols = table.columns
+    assert.equal(cols[0].width, 50, 'auto')
+    assert.equal(cols[1].width, 60, 'minCellWidth')
+    assert.equal(cols[2].width, 40, 'maxCellWidth')
+    assert.equal(cols[3].width, 60, 'minCellWidth should override maxCellWidth')
+    assert.equal(cols[4].width, cols[4].maxContentWidth, 'maxCellWidth max-content')
+    assert.equal(cols[5].width, cols[5].minContentWidth, 'minCellWidth min-content')
+  })
 
-    // this case will test if the space distribution is consistent for equal columns (important)
-    it('shrink: consistent distribution', () => {
-      const w1 = 1200,
-        w2 = 400,
-        r = -500
-      const col1 = new Column('col1', null, 0)
-      col1.width = w1
-      col1.wrappedWidth = w1
-      col1.minWidth = 350
-      const col2 = new Column('col2', null, 0)
-      col2.width = w2
-      col2.wrappedWidth = w2
-      col2.minWidth = 350
-      const col3 = new Column('col3', null, 0)
-      col3.width = w1
-      col3.wrappedWidth = w1
-      col3.minWidth = 350
-      const col4 = new Column('col4', null, 0)
-      col4.width = w2
-      col4.wrappedWidth = w2
-      col4.minWidth = 350
-
-      let resizeWidth = resizeColumns(
-        [col1, col2, col3, col4],
-        r,
-        (col) => col.minWidth
-      )
-      assert.equal(resizeWidth, 0, 'resizeWidth')
-      assert.equal(col1.width, col3.width, 'col1 = col3')
-      assert.equal(col2.width, col4.width, 'col2 = col4')
-
-      resizeWidth = resizeColumns(
-        [col1, col2, col4, col3],
-        r,
-        (col) => col.minWidth
-      )
-      assert.equal(resizeWidth, 0, 'resizeWidth')
-      assert.equal(col1.width, col3.width, 'col1 = col3')
-      assert.equal(col2.width, col4.width, 'col2 = col4')
+  it('minimize word-break', () => {
+    const doc = new jsPDF()
+    const input = parseInput(doc, {
+      body: [['abc', 'abc def', 'abcdef'.repeat(10), 'abc def'.repeat(10)]],
+      tableWidth: 50,
     })
+    const table = createTable(doc, input)
+    for (const col of table.columns) {
+      assert(col.minContentWidth > 0)
+      if (col.index === 2) {
+        assert(col.width < col.minContentWidth, 'shrink beyond minContentWidth')
+      } else {
+        assert.equal(col.width, col.minContentWidth, `minContentWidth ${col.index}`)
+      }
+    }
+  })
 
-    it('grow: two columns - no min', () => {
-      const w1 = 50,
-        w2 = 60,
-        r = 1000
-      const col1 = new Column('col1', null, 0)
-      col1.width = w1
-      col1.wrappedWidth = w1
-      const col2 = new Column('col2', null, 1)
-      col2.width = w2
-      col2.wrappedWidth = w2
-      const resizeWidth = resizeColumns([col1, col2], r, () => 0)
-      assert.equal(
-        Math.round(col1.width),
-        Math.round(w1 + r * (w1 / (w1 + w2))),
-        'col3 width'
-      )
-      assert.equal(
-        Math.round(col2.width),
-        Math.round(w2 + r * (w2 / (w1 + w2))),
-        'col2 width'
-      )
-      assert.equal(resizeWidth, 0, 'resizeWidth')
+  it('aggregate width styles', () => {
+    const doc = new jsPDF()
+    const input = parseInput(doc, {
+      head: [['0', '1', {content: '2', styles: {cellWidth: 10}}, '3', '4']],
+      body: [
+        [{content: '0', styles: {cellWidth: 10}}, {content: '1', styles: {minCellWidth: 100}}, '2', '3', '4'],
+        [{content: '0', styles: {cellWidth: 20}}, {content: '1', styles: {minCellWidth: 110}}, '2', '3', '4'],
+        ['0', '1', {content: '2', styles: {cellWidth: 5}}, {content: '3', styles: {maxCellWidth: 10}}, '4'],
+        ['0', '1', '2', {content: '3', styles: {maxCellWidth: 20}}, '4'],
+        ['0', '1', '2', '3', {content: '4', styles: {maxCellWidth: 10}}],
+      ],
+      columnStyles: {
+        0: {cellWidth: 15},
+        1: {minCellWidth: 105},
+        2: {minCellWidth: 100},
+        4: {maxCellWidth: 20},
+      },
+      tableWidth: 260,
     })
+    const table = createTable(doc, input)
+    const cols = table.columns
+    assert.equal(cols[0].width, 20, 'cellWidth')
+    assert.equal(cols[1].width, 110, 'minCellWidth')
+    assert.equal(cols[2].width, 100, 'cellWidth on head')
+    assert.equal(cols[3].width, 10, 'maxCellWidth')
+    assert.equal(cols[4].width, 20, 'maxCellWidth on columnStyles should override cells')
+  })
 
-    it('grow: three columns - col1 min', () => {
-      const w1 = 50,
-        w2 = 60,
-        w3 = 70,
-        r = 1000
-      const col1 = new Column('col1', null, 0)
-      col1.width = w1
-      col1.wrappedWidth = w1
-      col1.minWidth = 500
-      const col2 = new Column('col2', null, 1)
-      col2.width = w2
-      col2.wrappedWidth = w2
-      const col3 = new Column('col3', null, 1)
-      col3.width = w3
-      col3.wrappedWidth = w3
-      const resizeWidth = resizeColumns(
-        [col1, col2, col3],
-        r,
-        (col) => col.minWidth
-      )
-      assert.equal(col1.width, 500, 'col1 width')
-      assert.equal(
-        Math.round(col2.width),
-        Math.round(w2 + (r - col1.minWidth + w1) * (w2 / (w2 + w3))),
-        'col2 width'
-      )
-      assert.equal(
-        Math.round(col3.width),
-        Math.round(w3 + (r - col1.minWidth + w1) * (w3 / (w2 + w3))),
-        'col3 width'
-      )
-      assert.equal(resizeWidth, 0, 'resizeWidth')
+  it('reset column width', () => {
+    // Make sure width styles can be reset in columnStyles after been set in styles
+    const doc = new jsPDF()
+    const input = parseInput(doc, {
+      head: [{id: 'ID', name: 'Name', empty: '', info: 'Info'}],
+      body: [
+        {id: 'ID', name: 'Name', empty: '', info: 'Info'},
+      ],
+      foot: [{id: 'ID', name: 'Name', empty: '', info: 'Info'}],
+      styles: {
+        cellWidth: 'max-content',
+        minCellWidth: 10,
+        maxCellWidth: 20,
+        cellPadding: 0,
+      },
+      columnStyles: {
+        info: {cellWidth: 'auto', maxCellWidth: 'auto'},
+        empty: {minCellWidth: 0},
+      },
+      tableWidth: 200,
     })
+    const table = createTable(doc, input)
+    for (const col of table.columns) {
+      if (col.dataKey === 'empty') {
+        assert.equal(col.width, 0, 'empty col should have 0 width (minCellWidth: 0)')
+      } else if (col.dataKey === 'info') {
+        assert(col.width > 100, 'col should have auto width and grow to fill remaining width')
+      } else {
+        assert(col.width >= 10, 'minCellWidth')
+        assert(col.width <= 20, 'maxCellWidth')
+      }
+    }
   })
 })


### PR DESCRIPTION
Introducing new width options to give more dynamic control over the column widths


**Old options:**

```ts
  cellWidth: 'auto' | 'wrap' | number
  minCellWidth: number
  ---
  tableWidth: 'auto' | 'wrap' | number
```

**New options:**

```ts
  cellWidth: 'auto' | 'min-content' | 'max-content' | number
  minCellWidth: 'auto' | 'min-content' | 'max-content' | number
  maxCellWidth: 'auto' | 'min-content' | 'max-content' | number
  ---
  tableWidth: 'auto' | 'min-content' | 'max-content' | 'fit-content' | number
```

[min-content](https://developer.mozilla.org/en-US/docs/Web/CSS/min-content) : The minimum width required to fit the content in a readable manner (with no word-breaking).
[max-content](https://developer.mozilla.org/en-US/docs/Web/CSS/max-content) : The full-width required to fit the content without introducing new line-breaks (which was previously `wrap`).
[fit-content](https://developer.mozilla.org/en-US/docs/Web/CSS/fit-content) : (tableWidth only) Same as `max-content` but limited to the available page width.

These are CSS properties, so aligning with CSS naming is a plus here, but they are actually implemented in a more consistent and capable way than HTML/CSS tables which has somehow limited support for them.

Supporting these options across the width styles gives the ability to customize the table layout based on the content without resulting to use hard coded values which could be fiddly and never works well with dynamic content.

The width distribution algorithm has been rewritten to support the new options and has been improved to minimize word-breaking by default in case there was long columns with no spaces, in this case it will prioritize breaking the long columns first one by one in size-order, usually there's only one long column so this works well and prevent the short columns from breaking.

Using the example in #1018, here's the before and after (no custom width styles are used)

**Before:**

![318172315-abeb1663-180c-44b4-a9fb-d4e0b6928fa5](https://github.com/simonbengtsson/jsPDF-AutoTable/assets/5418859/ffddc4d8-b2ca-446b-bd54-8c8958e01e94)

**After:**

![image](https://github.com/simonbengtsson/jsPDF-AutoTable/assets/5418859/c19c2580-8af5-4cbf-8222-f69c82778d55)


---

I know this is a big change, so please take your time to review and let me know if you need any additional info.

Next this needs some work with horizontalPageBreak, it works but not fully, so to simplify the review I've decided to split it.

After that, I'll work on colSpans, which I actually started off by researching and refactoring for, but ended up with the new width options so finished it first. but I got the algorithm all planed thanks to CSS table layout specs & chromium source code.