### PR TITLE
Fix split when a nbsp character is present

### DIFF
--- a/src/widthCalculator.ts
+++ b/src/widthCalculator.ts
@@ -78,10 +78,10 @@ function calculate(doc: DocHandler, table: Table) {
       const padding = cell.padding('horizontal')
       cell.contentWidth = getStringWidth(cell.text, cell.styles, doc) + padding
 
-      // Using /[^\S\u00A0]+/ instead of \s ensures that we split the text on
-      // all whitespace except non-breaking spaces (\u00A0). We need to
-      // preserve them in the split process to ensure correct word separation
-      // and width calculation.
+      // Using [^\S\u00A0] instead of \s ensures that we split the text on all
+      // whitespace except non-breaking spaces (\u00A0). We need to preserve
+      // them in the split process to ensure correct word separation and width
+      // calculation.
       const longestWordWidth = getStringWidth(
         cell.text.join(' ').split(/[^\S\u00A0]+/),
         cell.styles,


### PR DESCRIPTION
When computing the `minReadableWidth` of a cell, the code does not account for non-breaking space characters (also known as `nbsp` or `\u00A0`).

nbsp characters should be treated as non-space characters when calculating the string length, as this is the intended function of such characters.

Failing to do so results in suboptimal output, particularly for languages like French, where punctuation marks such as colons (:) are always preceded by a space and should remain on the same line as the preceding word.

This PR fixes that issue.