### PR TITLE
Fix: Ensure consistent line rendering for cell borders

### DIFF
--- a/src/tableDrawer.ts
+++ b/src/tableDrawer.ts
@@ -1,6 +1,6 @@
 import autoTableText from './autoTableText'
 import { addTableBorder, getFillStyle } from './common'
-import { LineWidths } from './config'
+import { LineWidths, Color } from './config'
 import { DocHandler, jsPDFDocument } from './documentHandler'
 import { Cell, Column, Pos, Row, Table } from './models'
 import { assign } from './polyfills'
@@ -500,7 +500,7 @@ function drawCellBorders(
     if (lineWidth.left) {
       x1 -= 0.5 * lineWidth.left
     }
-    drawLine(lineWidth.top, x1, y1, x2, y2)
+    drawLine(lineWidth.top, x1, y1, x2, y2, cell.styles.lineColor)
   }
 
   if (lineWidth.bottom) {
@@ -514,7 +514,7 @@ function drawCellBorders(
     if (lineWidth.left) {
       x1 -= 0.5 * lineWidth.left
     }
-    drawLine(lineWidth.bottom, x1, y1, x2, y2)
+    drawLine(lineWidth.bottom, x1, y1, x2, y2, cell.styles.lineColor)
   }
 
   if (lineWidth.left) {
@@ -528,7 +528,7 @@ function drawCellBorders(
     if (lineWidth.bottom) {
       y2 += 0.5 * lineWidth.bottom
     }
-    drawLine(lineWidth.left, x1, y1, x2, y2)
+    drawLine(lineWidth.left, x1, y1, x2, y2, cell.styles.lineColor)
   }
 
   if (lineWidth.right) {
@@ -542,7 +542,7 @@ function drawCellBorders(
     if (lineWidth.bottom) {
       y2 += 0.5 * lineWidth.bottom
     }
-    drawLine(lineWidth.right, x1, y1, x2, y2)
+    drawLine(lineWidth.right, x1, y1, x2, y2, cell.styles.lineColor)
   }
 
   function drawLine(
@@ -551,9 +551,18 @@ function drawCellBorders(
     y1: number,
     x2: number,
     y2: number,
+    lineColor: Color,
   ) {
-    doc.getDocument().setLineWidth(width)
-    doc.getDocument().line(x1, y1, x2, y2, 'S')
+    const jsPDFDoc = doc.getDocument()
+    if (typeof lineColor === 'string') {
+      jsPDFDoc.setDrawColor(lineColor)
+    } else if (Array.isArray(lineColor)) {
+      jsPDFDoc.setDrawColor(lineColor[0], lineColor[1], lineColor[2])
+    } else if (typeof lineColor === 'number') {
+      jsPDFDoc.setDrawColor(lineColor)
+    }
+    jsPDFDoc.setLineWidth(width)
+    jsPDFDoc.line(x1, y1, x2, y2, 'S')
   }
 }
 


### PR DESCRIPTION
The issue reported that footer line widths were not appearing the same as header line widths, even when configured with the same numerical lineWidth value (e.g., 2) and color.

This was likely due to the jsPDF draw color state not being explicitly re-applied immediately before drawing each border segment within the `drawCellBorders` function. While `lineWidth` was set, the `lineColor` relied on an earlier `applyStyles` call, which could lead to inconsistencies if the state changed.

This commit modifies the `drawLine` helper function within `drawCellBorders` in `src/tableDrawer.ts` to:
1. Accept `cell.styles.lineColor` as a parameter.
2. Explicitly call `jsPDFDoc.setDrawColor()` with this color immediately before `jsPDFDoc.setLineWidth()` and the `jsPDFDoc.line()` command.

This ensures that both line width and line color are correctly set in the jsPDF graphics state for each border segment (top, bottom, left, right) for all cells, improving rendering consistency across table sections (head, body, foot).