### PR TITLE
feat(types): allow percentage values in CellWidthType

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -174,7 +174,7 @@ export type FontType = StandardFontType | CustomFontType;
 export type HAlignType = "left" | "center" | "right" | "justify";
 export type VAlignType = "top" | "middle" | "bottom";
 export type OverflowType = "linebreak" | "ellipsize" | "visible" | "hidden" | ((text: string | string[], width: number) => string | string[]);
-export type CellWidthType = "auto" | "wrap" | number;
+export type CellWidthType = "auto" | "wrap" | number | `${number}%`;
 export interface Styles {
 	font: FontType;
 	fontStyle: FontStyle;


### PR DESCRIPTION
Allow `$(number)%` to CellWidthType