### PR TITLE
Correct height calculation in the sections

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -93,9 +93,9 @@ export class Table {
   }
 
   getHeadHeight(columns: Column[]) {
-    var rowSpan = 0
+    var rowSpan = 1
     return this.head.reduce((acc, row) => { 
-      if(rowSpan === 0){
+      if(rowSpan === 1){
         rowSpan = row.getMaxRowSpan(columns)
         return acc + row.getMaxCellHeight(columns)
       }
@@ -105,9 +105,9 @@ export class Table {
   }
 
   getFootHeight(columns: Column[]) {
-    var rowSpan = 0
+    var rowSpan = 1
     return this.foot.reduce((acc, row) => { 
-      if(rowSpan === 0){
+      if(rowSpan === 1){
         rowSpan = row.getMaxRowSpan(columns)
         return acc + row.getMaxCellHeight(columns)
       }
@@ -207,7 +207,7 @@ export class Row {
     return columns.reduce(
       (acc, column) => Math.max(acc, this.cells[column.index]?.rowSpan || 0),
       0,
-    ) - 1
+    )
   }
 
   hasRowSpan(columns: Column[]) {

--- a/src/models.ts
+++ b/src/models.ts
@@ -93,27 +93,27 @@ export class Table {
   }
 
   getHeadHeight(columns: Column[]) {
-    var rowSpan = 0;
+    var rowSpan = 0
     return this.head.reduce((acc, row) => { 
       if(rowSpan === 0){
-        rowSpan = row.getMaxRowSpan(columns) - 1;
-        return acc + row.getMaxCellHeight(columns); 
+        rowSpan = row.getMaxRowSpan(columns)
+        return acc + row.getMaxCellHeight(columns)
       }
       rowSpan--
       return acc
-    }, 0);
+    }, 0)
   }
 
   getFootHeight(columns: Column[]) {
-    var rowSpan = 0;
+    var rowSpan = 0
     return this.foot.reduce((acc, row) => { 
       if(rowSpan === 0){
-        rowSpan = row.getMaxRowSpan(columns) - 1;
-        return acc + row.getMaxCellHeight(columns); 
+        rowSpan = row.getMaxRowSpan(columns)
+        return acc + row.getMaxCellHeight(columns)
       }
       rowSpan--
       return acc
-    }, 0);
+    }, 0)
   }
 
   allRows() {
@@ -207,7 +207,7 @@ export class Row {
     return columns.reduce(
       (acc, column) => Math.max(acc, this.cells[column.index]?.rowSpan || 0),
       0,
-    )
+    ) - 1
   }
 
   hasRowSpan(columns: Column[]) {

--- a/src/models.ts
+++ b/src/models.ts
@@ -93,17 +93,27 @@ export class Table {
   }
 
   getHeadHeight(columns: Column[]) {
-    return this.head.reduce(
-      (acc, row) => acc + row.getMaxCellHeight(columns),
-      0,
-    )
+    var rowSpan = 0;
+    return this.head.reduce((acc, row) => { 
+      if(rowSpan === 0){
+        rowSpan = row.getMaxRowSpan(columns) - 1;
+        return acc + row.getMaxCellHeight(columns); 
+      }
+      rowSpan--
+      return acc
+    }, 0);
   }
 
   getFootHeight(columns: Column[]) {
-    return this.foot.reduce(
-      (acc, row) => acc + row.getMaxCellHeight(columns),
-      0,
-    )
+    var rowSpan = 0;
+    return this.foot.reduce((acc, row) => { 
+      if(rowSpan === 0){
+        rowSpan = row.getMaxRowSpan(columns) - 1;
+        return acc + row.getMaxCellHeight(columns); 
+      }
+      rowSpan--
+      return acc
+    }, 0);
   }
 
   allRows() {
@@ -189,6 +199,13 @@ export class Row {
   getMaxCellHeight(columns: Column[]) {
     return columns.reduce(
       (acc, column) => Math.max(acc, this.cells[column.index]?.height || 0),
+      0,
+    )
+  }
+
+  getMaxRowSpan(columns: Column[]) {
+    return columns.reduce(
+      (acc, column) => Math.max(acc, this.cells[column.index]?.rowSpan || 0),
       0,
     )
   }


### PR DESCRIPTION
This code corrects the calculation of the height of the sections when using rowSpan in them since the original code oversized the height of the sections with the dimension of the rows that do not have rowSpan which causes an anticipated page break. 