### PR TITLE
Incomplete row on page break

### DIFF
--- a/src/tableDrawer.ts
+++ b/src/tableDrawer.ts
@@ -382,7 +382,6 @@ function printFullRow(
   } else if (shouldPrintOnCurrentPage(doc, row, remainingSpace, table)) {
     // The row gets split in two here, each piece in one page
     const remainderRow = modifyRowToFit(row, remainingSpace, table, doc)
-    printRow(doc, table, row, cursor, columns)
     addPage(doc, table, startPos, cursor, columns)
     printFullRow(doc, table, remainderRow, isLastRow, startPos, cursor, columns)
   } else {


### PR DESCRIPTION
delete this line of code as it creates a row that looks incomplete in the full tables if the height of the table is less than the available height to draw it and the smallest difference at the height of the last row. 